### PR TITLE
Suggest 'mcs update --all-projects' in pack update hints

### DIFF
--- a/Sources/mcs/Commands/PackCommand.swift
+++ b/Sources/mcs/Commands/PackCommand.swift
@@ -700,7 +700,7 @@ struct UpdatePack: LockedCommand {
                 throw ExitCode.failure
             }
             ctx.output.plain("")
-            ctx.output.info("Run 'mcs update' to apply updates across all configured scopes.")
+            ctx.output.info("Run 'mcs update --all-projects' to apply updates across every configured project plus the global scope.")
         }
 
         if PackUpdater.shouldExitNonZero(

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -605,7 +605,10 @@ struct UpdateChecker {
                     let remote = String(pack.remoteSHA.prefix(7))
                     output.plain("         \u{2022} \(pack.displayName) (\(local) \u{2192} \(remote))")
                 }
-                output.plain("       Run 'mcs update' to update and re-apply across configured scopes.")
+                output.plain(
+                    "       Run 'mcs update --all-projects' to update and re-apply across every"
+                        + " configured project plus the global scope."
+                )
             }
         }
 
@@ -632,7 +635,7 @@ struct UpdateChecker {
             let noun = result.packUpdates.count == 1 ? "tech pack has" : "tech packs have"
             lines.append(
                 "- \(result.packUpdates.count) \(noun) updates available: \(names)."
-                    + " The user should run: mcs update"
+                    + " The user should run: mcs update --all-projects"
             )
         }
         return lines.joined(separator: "\n")


### PR DESCRIPTION
## Summary

The update notification told users to run `mcs update`, which only refreshes the current project plus the global scope. On a machine with packs configured across several projects, following that hint leaves every other project stale — the "I ran update, why is this one still old?" confusion. The hints now name the machine-wide refresh, which keeps its existing confirmation prompt before fanning out.

## Changes

- The terminal update notice and the SessionStart hook context passed to Claude Code both suggest `mcs update --all-projects`.
- The hint printed after `mcs pack update` already promised "all configured scopes" while suggesting a command that did not reach them.

## Test plan

- [x] `swift test` passes locally
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [x] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

`swiftlint` is clean. `swiftformat` did not run locally — the installed 0.58.7 rejects `wrapIfStatementBodies` in `.swiftformat` as an unknown rule; CI upgrades to latest, so this is a local-toolchain gap, not a change from this PR.

Manual check: with a pack behind its remote, run `mcs check-updates` → the notice should name `mcs update --all-projects`.