### PR TITLE
ISSUE-369: Block globally-installed packs from project sync

### DIFF
--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -84,14 +84,7 @@ struct SyncCommand: LockedCommand {
             strategy: GlobalSyncStrategy(environment: env)
         )
 
-        let persistedExclusions: [String: Set<String>]
-        do {
-            persistedExclusions = try ProjectState(stateFile: env.globalStateFile).allExcludedComponents
-        } catch {
-            output.error("Corrupt global state: \(error.localizedDescription)")
-            output.error("Delete \(env.globalStateFile.path) and re-run 'mcs sync --global'.")
-            throw ExitCode.failure
-        }
+        let persistedExclusions = try loadGlobalState(env: env, output: output).allExcludedComponents
 
         if all || !pack.isEmpty {
             let packs = try resolvePacks(from: registry, output: output)
@@ -105,7 +98,11 @@ struct SyncCommand: LockedCommand {
                 output: output
             )
         } else {
-            try configurator.interactiveConfigure(dryRun: dryRun, customize: customize)
+            try configurator.interactiveConfigure(
+                dryRun: dryRun,
+                customize: customize,
+                globallyInstalledPacks: []
+            )
         }
     }
 
@@ -142,17 +139,26 @@ struct SyncCommand: LockedCommand {
             strategy: ProjectSyncStrategy(projectPath: projectPath, environment: env)
         )
 
-        let persistedExclusions: [String: Set<String>]
+        let projectState: ProjectState
         do {
-            persistedExclusions = try ProjectState(projectRoot: projectPath).allExcludedComponents
+            projectState = try ProjectState(projectRoot: projectPath)
         } catch {
             output.error("Corrupt .mcs-project: \(error.localizedDescription)")
             output.error("Delete .claude/.mcs-project and re-run 'mcs sync'.")
             throw ExitCode.failure
         }
+        let persistedExclusions = projectState.allExcludedComponents
+        let previouslyConfigured = projectState.configuredPacks
+
+        let globallyInstalledPacks = try loadGlobalState(env: env, output: output).configuredPacks
 
         if all || !pack.isEmpty {
-            let packs = try resolvePacks(from: registry, output: output)
+            let packs = try Self.filterGloballyBlocked(
+                resolvePacks(from: registry, output: output),
+                globallyInstalled: globallyInstalledPacks,
+                previouslyConfigured: previouslyConfigured,
+                output: output
+            )
             try runSync(
                 configurator: configurator,
                 packs: packs,
@@ -163,7 +169,11 @@ struct SyncCommand: LockedCommand {
                 output: output
             )
         } else {
-            try configurator.interactiveConfigure(dryRun: dryRun, customize: customize)
+            try configurator.interactiveConfigure(
+                dryRun: dryRun,
+                customize: customize,
+                globallyInstalledPacks: globallyInstalledPacks
+            )
         }
 
         switch Self.lockfileAction(dryRun: dryRun, config: config) {
@@ -191,6 +201,60 @@ struct SyncCommand: LockedCommand {
         if config.isLockfileGenerationEnabled { return .write }
         if config.isLockfileGenerationUnset { return .reportDrift }
         return .skip
+    }
+
+    // MARK: - Global Pack Blocking
+
+    /// Load global state, failing the command with an actionable message if the file is
+    /// corrupt. A *missing* file is not an error — `ProjectState.load` returns early and
+    /// yields an empty state, so machines that never ran `--global` are unaffected.
+    private func loadGlobalState(env: Environment, output: CLIOutput) throws -> ProjectState {
+        do {
+            return try ProjectState(stateFile: env.globalStateFile)
+        } catch {
+            output.error("Corrupt global state: \(error.localizedDescription)")
+            output.error("Delete \(env.globalStateFile.path) and re-run 'mcs sync --global'.")
+            throw ExitCode.failure
+        }
+    }
+
+    /// Drop globally-blocked packs from a non-interactive pack set, reporting what was
+    /// skipped. Skipping is safe precisely because a blocked pack is not configured
+    /// here, so removing it from the desired set cannot unconfigure anything.
+    ///
+    /// `static` so tests can drive the real filter — `SyncCommand` builds its own
+    /// `Environment()`, so instance paths are not reachable from a sandboxed test bed.
+    static func filterGloballyBlocked(
+        _ packs: [any TechPack],
+        globallyInstalled: Set<String>,
+        previouslyConfigured: Set<String>,
+        output: CLIOutput
+    ) throws -> [any TechPack] {
+        let blocked = ConfiguratorSupport.globallyBlockedIDs(
+            candidates: packs.map(\.identifier),
+            globallyInstalled: globallyInstalled,
+            previouslyConfigured: previouslyConfigured
+        )
+        guard !blocked.isEmpty else { return packs }
+
+        // Display names, matching the picker's "Already installed globally" section.
+        // The same packs must not be named differently depending on the flag used.
+        let blockedNames = packs
+            .filter { blocked.contains($0.identifier) }
+            .map(\.displayName)
+            .sorted()
+        output.warn("Skipping \(blocked.count) pack(s) already installed globally:")
+        output.plain("  \(blockedNames.joined(separator: ", "))")
+        output.plain("  Run 'mcs sync --global' to manage them.")
+
+        let remaining = packs.filter { !blocked.contains($0.identifier) }
+        // `resolvePacks` guarantees a non-empty result, but filtering happens after it.
+        // Syncing an empty desired set would unconfigure every pack in the project.
+        guard !remaining.isEmpty else {
+            output.error("All requested packs are already installed globally. Nothing to sync.")
+            throw ExitCode.failure
+        }
+        return remaining
     }
 
     // MARK: - Shared Helpers
@@ -299,8 +363,8 @@ struct SyncCommand: LockedCommand {
     ) throws {
         output.header("Sync \(scopeLabel)")
         output.plain("")
-        output.info("\(targetLabel): \(targetPath)")
-        output.info("Packs: \(packs.map(\.displayName).joined(separator: ", "))")
+        output.info(label: targetLabel, targetPath)
+        output.info(label: "Packs", packs.map(\.displayName).joined(separator: ", "))
 
         if dryRun {
             try configurator.dryRun(packs: packs)

--- a/Sources/mcs/Core/CLIOutput.swift
+++ b/Sources/mcs/Core/CLIOutput.swift
@@ -141,6 +141,22 @@ struct CLIOutput {
         return rows
     }
 
+    /// The "Already installed globally" block, shared by the interactive and fallback
+    /// pickers so a copy edit cannot land on only one of them. Returns `""` when there
+    /// is nothing locked, letting callers append unconditionally.
+    private func lockedSectionString(_ names: [String], indent: String) -> String {
+        guard !names.isEmpty else { return "" }
+
+        var out = "\n" + sectionHeaderString("Already installed globally")
+        for name in names {
+            // ✓ rather than ●/○: those are toggle glyphs and would read as a checkbox.
+            // ✓ states a fact. Same green as "Always included" — both sections mean
+            // "you already have this", and the headers disambiguate.
+            out += "\(indent)\(green)\u{2713}\(reset) \(name)\n"
+        }
+        return out + "\n\(indent)\(dim)Manage these with 'mcs sync --global'\(reset)\n"
+    }
+
     private func sectionHeaderString(_ title: String) -> String {
         let divider = "──────────────────────────────────────────"
         return "  \(bold)\(title)\(reset)\n  \(dim)\(divider)\(reset)\n"
@@ -150,6 +166,12 @@ struct CLIOutput {
 
     func info(_ message: String) {
         write("\(blue)[INFO]\(reset) \(message)\n")
+    }
+
+    /// `[INFO] <bold label>: <value>` — emphasises the label, and keeps that emphasis
+    /// identical across the sync summary lines without callers handling escape codes.
+    func info(label: String, _ value: String) {
+        write("\(blue)[INFO]\(reset) \(bold)\(label):\(reset) \(value)\n")
     }
 
     func success(_ message: String) {
@@ -568,7 +590,9 @@ struct CLIOutput {
         }
     }
 
-    private func buildInteractiveListString(
+    /// Internal rather than private so the rendered layout can be asserted directly;
+    /// it is a pure function of its arguments and touches no terminal state.
+    func buildInteractiveListString(
         groups: [SelectableGroup],
         cursor: Int,
         columns: Int
@@ -595,10 +619,13 @@ struct CLIOutput {
                     : "\(dim)\u{25CB}\(reset)"
                 let pointer = isCursor ? "\(cyan)\u{276F}\(reset)" : " "
                 let nameStyle = isCursor ? "\(bold)\(cyan)\(item.name)\(reset)" : "\(bold)\(item.name)\(reset)"
+                // Badge and tag must stay on the name's line — `visualRowCount`
+                // soft-wrap math counts visible characters per rendered line.
+                let badge = item.globallyInstalled ? "\(dim) (global)\(reset)" : ""
                 let tag = group.showsDelta
                     ? PickerDelta.tagString(state: state, isCursor: isCursor, style: style)
                     : ""
-                output += "  \(pointer) \(marker) \(nameStyle)\(tag)\n"
+                output += "  \(pointer) \(marker) \(nameStyle)\(badge)\(tag)\n"
                 output += "\(dim)\(wordWrap(item.description, indent: "      ", columns: columns))\(reset)\n"
 
                 if group.showsDelta {
@@ -614,6 +641,8 @@ struct CLIOutput {
                 flatIndex += 1
             }
         }
+
+        output += lockedSectionString(groups.flatMap(\.lockedItems), indent: "    ")
 
         let allRequired = groups.flatMap(\.requiredItems)
         if !allRequired.isEmpty {
@@ -756,10 +785,13 @@ struct CLIOutput {
                     ? "\(green)\u{25CF}\(reset)"
                     : "\(dim)\u{25CB}\(reset)"
                 let numStr = String(format: "%2d", item.number)
-                write("  [\(numStr)]  \(marker) \(bold)\(item.name)\(reset)\n")
+                let badge = item.globallyInstalled ? "\(dim) (global)\(reset)" : ""
+                write("  [\(numStr)]  \(marker) \(bold)\(item.name)\(reset)\(badge)\n")
                 write("         \(dim)\(item.description)\(reset)\n")
             }
         }
+
+        write(lockedSectionString(groups.flatMap(\.lockedItems), indent: "       "))
 
         let allRequired = groups.flatMap(\.requiredItems)
         if !allRequired.isEmpty {
@@ -816,6 +848,11 @@ struct SelectableItem {
     /// Only meaningful when the enclosing `SelectableGroup.showsDelta == true`;
     /// otherwise ignored by the renderer.
     var baselineSelected: Bool = false
+    /// The pack is also installed in the global scope, so its artifacts are
+    /// duplicated here. Only ever true for rows that are *also* installed in this
+    /// project — a global pack absent from the project is not selectable at all and
+    /// is listed in `SelectableGroup.lockedItems` instead.
+    var globallyInstalled: Bool = false
 }
 
 struct RequiredItem {
@@ -830,6 +867,10 @@ struct SelectableGroup {
     /// dynamic footer. Callers must populate `baselineSelected` on every item
     /// or the renderer will treat pre-installed packs as brand-new.
     var showsDelta: Bool = false
+    /// Names shown in a non-navigable "Already installed globally" section. These are
+    /// deliberately not `SelectableItem`s: keeping them out of the cursor's item list
+    /// is what makes them unselectable, rather than guarding every input path.
+    var lockedItems: [String] = []
 }
 
 // MARK: - Multi-Select Parser

--- a/Sources/mcs/Sync/Configurator.swift
+++ b/Sources/mcs/Sync/Configurator.swift
@@ -39,7 +39,14 @@ struct Configurator {
     /// Full interactive configure flow — multi-select of registered packs.
     ///
     /// - Parameter customize: When `true`, present per-pack component multi-select after pack selection.
-    func interactiveConfigure(dryRun: Bool = false, customize: Bool = false) throws {
+    /// - Parameter globallyInstalledPacks: Identifiers configured in the global scope.
+    ///   Deliberately has no default: omitting it would silently disable the block, and
+    ///   "I have no global state to report" must be stated, not defaulted into.
+    func interactiveConfigure(
+        dryRun: Bool = false,
+        customize: Bool = false,
+        globallyInstalledPacks: Set<String>
+    ) throws {
         // Piped/closed stdin means the confirmation prompt silently returns its default,
         // which would look like a successful sync while applying nothing. Fail loudly
         // and point at non-interactive flags. Note: `hasInteractiveStdin` (not
@@ -54,9 +61,9 @@ struct Configurator {
         output.header("Sync \(scope.label)")
         output.plain("")
         if scope.isGlobalScope {
-            output.info("Target: \(scope.targetPath.path)")
+            output.info(label: "Target", scope.targetPath.path)
         } else {
-            output.info("Project: \(scope.targetPath.deletingLastPathComponent().path)")
+            output.info(label: "Project", scope.targetPath.deletingLastPathComponent().path)
         }
 
         let packs = registry.availablePacks
@@ -68,14 +75,27 @@ struct Configurator {
         let previousState = try ProjectState(stateFile: scope.stateFile)
         let previousPacks = previousState.configuredPacks
 
-        let items = packs.enumerated().map { index, pack in
+        // Global sync installs *into* the global scope, so nothing there can block it.
+        // Enforced here rather than trusted to callers.
+        let blocked = scope.isGlobalScope ? [] : ConfiguratorSupport.globallyBlockedIDs(
+            candidates: packs.map(\.identifier),
+            globallyInstalled: globallyInstalledPacks,
+            previouslyConfigured: previousPacks
+        )
+        let selectablePacks = packs.filter { !blocked.contains($0.identifier) }
+        let lockedNames = packs.filter { blocked.contains($0.identifier) }.map(\.displayName)
+
+        // Numbering follows `selectablePacks`, not `packs`, so the fallback picker's
+        // typed numbers stay contiguous and map back cleanly below.
+        let items = selectablePacks.enumerated().map { index, pack in
             let installed = previousPacks.contains(pack.identifier)
             return SelectableItem(
                 number: index + 1,
                 name: pack.displayName,
                 description: pack.description,
                 isSelected: installed,
-                baselineSelected: installed
+                baselineSelected: installed,
+                globallyInstalled: globallyInstalledPacks.contains(pack.identifier)
             )
         }
 
@@ -86,7 +106,8 @@ struct Configurator {
             title: groupTitle,
             items: items,
             requiredItems: [],
-            showsDelta: true
+            showsDelta: true,
+            lockedItems: lockedNames
         )]
 
         output.plain("")
@@ -94,7 +115,7 @@ struct Configurator {
 
         let selectedNumbers = output.multiSelect(groups: &groups)
 
-        let selectedPacks = packs.enumerated().compactMap { index, pack in
+        let selectedPacks = selectablePacks.enumerated().compactMap { index, pack in
             selectedNumbers.contains(index + 1) ? pack : nil
         }
 

--- a/Sources/mcs/Sync/Configurator.swift
+++ b/Sources/mcs/Sync/Configurator.swift
@@ -85,6 +85,18 @@ struct Configurator {
         let selectablePacks = packs.filter { !blocked.contains($0.identifier) }
         let lockedNames = packs.filter { blocked.contains($0.identifier) }.map(\.displayName)
 
+        // Every registered pack is global, so the picker would have no selectable rows —
+        // and `interactiveMultiSelect` returns before rendering when it has none, hiding
+        // the locked section entirely. Explain here, where the reason is known.
+        // `previousPacks.isEmpty` keeps stale configured packs converging as before.
+        if selectablePacks.isEmpty, !lockedNames.isEmpty, previousPacks.isEmpty {
+            output.plain("")
+            output.info("All registered packs are already installed globally:")
+            output.plain("  \(lockedNames.sorted().joined(separator: ", "))")
+            output.plain("  They already apply here. Run 'mcs sync --global' to manage them.")
+            return
+        }
+
         // Numbering follows `selectablePacks`, not `packs`, so the fallback picker's
         // typed numbers stay contiguous and map back cleanly below.
         let items = selectablePacks.enumerated().map { index, pack in

--- a/Sources/mcs/Sync/ConfiguratorSupport.swift
+++ b/Sources/mcs/Sync/ConfiguratorSupport.swift
@@ -4,6 +4,26 @@ import Foundation
 ///
 /// Eliminates duplication of common methods that both configurators need.
 enum ConfiguratorSupport {
+    /// Pack identifiers that may not be installed into a project because they are
+    /// already installed globally.
+    ///
+    /// The block is a rule about *transitions*: a pack already configured here is
+    /// never blocked. Blocking by bare identity would drop both-scope packs from the
+    /// desired set, and `Configurator.configure` removes anything missing from it —
+    /// with `confirmRemovals: false` on the `--all`/`--pack` path, silently.
+    ///
+    /// Shared by the interactive picker (which lists these separately, unselectable)
+    /// and `SyncCommand`'s non-interactive filter, so the rule has one definition.
+    static func globallyBlockedIDs(
+        candidates: [String],
+        globallyInstalled: Set<String>,
+        previouslyConfigured: Set<String>
+    ) -> Set<String> {
+        Set(candidates.filter {
+            globallyInstalled.contains($0) && !previouslyConfigured.contains($0)
+        })
+    }
+
     /// Build a `ComponentExecutor` from the common dependencies.
     static func makeExecutor(
         environment: Environment,

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -1993,3 +1993,122 @@ struct PromptValueReuseLifecycleTests {
         #expect(try bed.projectState().resolvedValues?["SETTING"] == "prior-updated")
     }
 }
+
+// MARK: - Global Pack Blocking
+
+/// End-to-end coverage for blocking globally-installed packs from project sync.
+///
+/// These drive `Configurator` directly rather than `SyncCommand.perform()`, which
+/// builds its own `Environment()` and cannot be pointed at a sandboxed home.
+struct GlobalPackBlockingLifecycleTests {
+    @Test("Global-only pack is filtered out and never reaches project state")
+    func globalOnlyPackIsNotInstalledInProject() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let shared = MockTechPack(identifier: "shared-pack", displayName: "Shared Pack")
+        let projectOnly = MockTechPack(identifier: "project-pack", displayName: "Project Pack")
+        let registry = TechPackRegistry(packs: [shared, projectOnly])
+
+        // Install `shared-pack` globally.
+        try bed.makeGlobalSyncConfigurator(registry: registry)
+            .configure(packs: [shared], confirmRemovals: false)
+
+        let globallyInstalled = try ProjectState(stateFile: bed.env.globalStateFile).configuredPacks
+        #expect(globallyInstalled.contains("shared-pack"))
+
+        // `mcs sync --all` in the project: both packs are candidates, `shared-pack`
+        // is blocked because it is global and not yet configured here. Drive the real
+        // filter, not a copy of it — a reimplementation here would keep passing even
+        // if `performProject` stopped calling it.
+        let toSync = try SyncCommand.filterGloballyBlocked(
+            [shared, projectOnly],
+            globallyInstalled: globallyInstalled,
+            previouslyConfigured: bed.projectState().configuredPacks,
+            output: CLIOutput(colorsEnabled: false)
+        )
+        #expect(toSync.map(\.identifier) == ["project-pack"])
+
+        try bed.makeConfigurator(registry: registry)
+            .configure(packs: toSync, confirmRemovals: false)
+
+        let projectPacks = try bed.projectState().configuredPacks
+        #expect(!projectPacks.contains("shared-pack"))
+        #expect(projectPacks.contains("project-pack"))
+    }
+
+    @Test("Both-scope pack survives a project sync instead of being silently removed")
+    func bothScopePackSurvivesProjectSync() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let shared = MockTechPack(identifier: "shared-pack", displayName: "Shared Pack")
+        let registry = TechPackRegistry(packs: [shared])
+
+        // Pre-existing state: installed in the project FIRST, then globally.
+        try bed.makeConfigurator(registry: registry)
+            .configure(packs: [shared], confirmRemovals: false)
+        try bed.makeGlobalSyncConfigurator(registry: registry)
+            .configure(packs: [shared], confirmRemovals: false)
+
+        #expect(try bed.projectState().configuredPacks.contains("shared-pack"))
+
+        // The regression guard: blocking by bare identity here would drop the pack
+        // from the desired set, and `configure(confirmRemovals: false)` would
+        // unconfigure it without a prompt.
+        let toSync = try SyncCommand.filterGloballyBlocked(
+            [shared],
+            globallyInstalled: ProjectState(stateFile: bed.env.globalStateFile).configuredPacks,
+            previouslyConfigured: bed.projectState().configuredPacks,
+            output: CLIOutput(colorsEnabled: false)
+        )
+        #expect(toSync.map(\.identifier) == ["shared-pack"])
+
+        try bed.makeConfigurator(registry: registry)
+            .configure(packs: toSync, confirmRemovals: false)
+
+        #expect(try bed.projectState().configuredPacks.contains("shared-pack"))
+    }
+
+    @Test("Missing global state blocks nothing — machines that never ran --global")
+    func missingGlobalStateBlocksNothing() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        #expect(!FileManager.default.fileExists(atPath: bed.env.globalStateFile.path))
+
+        let pack = MockTechPack(identifier: "ios", displayName: "iOS")
+        // `ProjectState.load` returns early for a missing file rather than throwing,
+        // so an untouched global scope yields an empty set and nothing is filtered.
+        let toSync = try SyncCommand.filterGloballyBlocked(
+            [pack],
+            globallyInstalled: ProjectState(stateFile: bed.env.globalStateFile).configuredPacks,
+            previouslyConfigured: [],
+            output: CLIOutput(colorsEnabled: false)
+        )
+        #expect(toSync.map(\.identifier) == ["ios"])
+    }
+
+    @Test("Refuses to sync when every requested pack is globally installed")
+    func refusesWhenEveryPackIsBlocked() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let shared = MockTechPack(identifier: "shared-pack", displayName: "Shared Pack")
+        let registry = TechPackRegistry(packs: [shared])
+
+        try bed.makeGlobalSyncConfigurator(registry: registry)
+            .configure(packs: [shared], confirmRemovals: false)
+
+        // Returning an empty pack list instead of throwing would make `configure`
+        // converge on an empty desired set and unconfigure the whole project.
+        #expect(throws: (any Error).self) {
+            try SyncCommand.filterGloballyBlocked(
+                [shared],
+                globallyInstalled: ProjectState(stateFile: bed.env.globalStateFile).configuredPacks,
+                previouslyConfigured: [],
+                output: CLIOutput(colorsEnabled: false)
+            )
+        }
+    }
+}

--- a/Tests/MCSTests/PickerDeltaTests.swift
+++ b/Tests/MCSTests/PickerDeltaTests.swift
@@ -105,4 +105,81 @@ struct PickerDeltaTests {
         #expect(rendered.contains("\u{1B}[0;31m"))
         #expect(rendered.contains("\u{1B}[2m"))
     }
+
+    // MARK: - Locked section rendering
+
+    private func render(
+        items: [SelectableItem],
+        locked: [String],
+        colors: Bool = false
+    ) -> String {
+        let group = SelectableGroup(
+            title: "Packs",
+            items: items,
+            requiredItems: [],
+            showsDelta: true,
+            lockedItems: locked
+        )
+        return CLIOutput(colorsEnabled: colors)
+            .buildInteractiveListString(groups: [group], cursor: 0, columns: 100)
+    }
+
+    private func item(_ name: String, selected: Bool, global: Bool = false) -> SelectableItem {
+        SelectableItem(
+            number: 1, name: name, description: "desc",
+            isSelected: selected, baselineSelected: selected, globallyInstalled: global
+        )
+    }
+
+    @Test("Locked packs render in their own section, not as selectable rows")
+    func lockedSectionRendered() {
+        let out = render(items: [item("backend", selected: false)], locked: ["dev-essentials"])
+
+        #expect(out.contains("Already installed globally"))
+        #expect(out.contains("dev-essentials"))
+        #expect(out.contains("Manage these with 'mcs sync --global'"))
+    }
+
+    @Test("Locked packs use the fact glyph, never the selectable toggle glyphs")
+    func lockedUsesCheckNotToggle() {
+        let out = render(items: [], locked: ["dev-essentials"])
+
+        // Toggle glyphs would read as a checkbox the user can flip; this row is a
+        // statement of fact, which is the whole point of the separate section.
+        #expect(out.contains("\u{2713} dev-essentials"))
+        #expect(!out.contains("\u{25CF} dev-essentials"))
+        #expect(!out.contains("\u{25CB} dev-essentials"))
+    }
+
+    @Test("Locked check reuses the green always-included check")
+    func lockedCheckIsGreen() {
+        let out = render(items: [], locked: ["dev-essentials"], colors: true)
+        let greenCheck = "\u{1B}[0;32m\u{2713}"
+
+        #expect(out.contains(greenCheck))
+    }
+
+    @Test("No locked section rendered when nothing is locked")
+    func noLockedSectionWhenEmpty() {
+        let out = render(items: [item("backend", selected: false)], locked: [])
+
+        #expect(!out.contains("Already installed globally"))
+    }
+
+    @Test("A both-scope pack stays a selectable row and carries the (global) badge")
+    func bothScopePackStaysSelectable() {
+        let out = render(items: [item("ios", selected: true, global: true)], locked: [])
+
+        #expect(out.contains("(global)"))
+        // Still a real toggle: it is installed here and must remain removable.
+        #expect(out.contains("\u{25CF}"))
+        #expect(out.contains("installed \u{00B7} uncheck to remove"))
+    }
+
+    @Test("Locked names are excluded from the add/remove/unchanged counter")
+    func lockedNotCounted() {
+        let out = render(items: [item("backend", selected: false)], locked: ["a", "b", "c"])
+
+        #expect(out.contains("+0 to add \u{00B7} -0 to remove \u{00B7} 1 unchanged"))
+    }
 }

--- a/Tests/MCSTests/ProjectStateTests.swift
+++ b/Tests/MCSTests/ProjectStateTests.swift
@@ -92,4 +92,19 @@ struct PackArtifactRecordTests {
         #expect(loadedArtifacts?.plugins == ["pr-review-toolkit"])
         #expect(loadedArtifacts?.mcpServers.count == 1)
     }
+
+    @Test("Throws on malformed JSON so callers can surface an actionable message")
+    func throwsOnMalformedJSON() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mcs-state-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = dir.appendingPathComponent("state.json")
+        try "{ not valid json".write(to: file, atomically: true, encoding: .utf8)
+
+        #expect(throws: (any Error).self) {
+            try ProjectState(stateFile: file)
+        }
+    }
 }

--- a/Tests/MCSTests/SyncCommandTests.swift
+++ b/Tests/MCSTests/SyncCommandTests.swift
@@ -139,6 +139,64 @@ struct SyncCommandTests {
         config.generateLockfile = false
         #expect(SyncCommand.lockfileAction(dryRun: false, config: config) == .skip)
     }
+
+    // MARK: - Global pack blocking
+
+    @Test("Blocks a pack installed globally but not in this project")
+    func blocksGlobalOnlyPack() {
+        let blocked = ConfiguratorSupport.globallyBlockedIDs(
+            candidates: ["ios", "android"],
+            globallyInstalled: ["ios"],
+            previouslyConfigured: []
+        )
+        #expect(blocked == ["ios"])
+    }
+
+    @Test("Does NOT block a pack installed in both scopes")
+    func doesNotBlockBothScopePack() {
+        // The critical case: blocking here would drop the pack from the desired set,
+        // and `runSync` passes confirmRemovals: false — `mcs sync --all` would
+        // silently unconfigure it.
+        let blocked = ConfiguratorSupport.globallyBlockedIDs(
+            candidates: ["ios", "android"],
+            globallyInstalled: ["ios"],
+            previouslyConfigured: ["ios"]
+        )
+        #expect(blocked.isEmpty)
+    }
+
+    @Test("Ignores project-only packs and packs absent from the candidate set")
+    func ignoresUnrelatedPacks() {
+        let blocked = ConfiguratorSupport.globallyBlockedIDs(
+            candidates: ["android"],
+            globallyInstalled: ["ios", "tooling"],
+            previouslyConfigured: ["android"]
+        )
+        #expect(blocked.isEmpty)
+    }
+
+    @Test("Blocking every candidate is detectable so the caller can refuse an empty sync")
+    func blocksEveryCandidate() {
+        let candidates = ["ios", "tooling"]
+        let blocked = ConfiguratorSupport.globallyBlockedIDs(
+            candidates: candidates,
+            globallyInstalled: ["ios", "tooling"],
+            previouslyConfigured: []
+        )
+        // Caller must error rather than converge on an empty desired set, which
+        // would unconfigure every pack in the project.
+        #expect(blocked == Set(candidates))
+    }
+
+    @Test("Empty global state blocks nothing — machines that never ran --global")
+    func emptyGlobalStateBlocksNothing() {
+        let blocked = ConfiguratorSupport.globallyBlockedIDs(
+            candidates: ["ios", "android"],
+            globallyInstalled: [],
+            previouslyConfigured: []
+        )
+        #expect(blocked.isEmpty)
+    }
 }
 
 // MARK: - Guard: cwd inside ~/.claude detection


### PR DESCRIPTION
## Why

A pack installed globally already applies to every project, but `mcs sync` gave no sign of that, so users re-installed the same packs per-project. The duplicate is not cosmetic: the global and project copies of a hook are registered as distinct entries and both fire, and skills, agents and commands are duplicated the same way.

Globally-installed packs are now listed separately in the picker and cannot be added to a project — interactively or via `--all`/`--pack`. The rule is deliberately about *transitions*, not identity: a pack already installed in both scopes stays selectable so it can still be removed from the project. Blocking those as well would drop them from the desired pack set, which `mcs sync --all` converges on with no confirmation prompt — silently uninstalling them.

`mcs sync --global` is unaffected, as is `mcs update`.

Closes #369

## Test plan

1. `mcs sync --global`, select a pack. Then `mcs sync` in a project → expect that pack under "Already installed globally", with the cursor unable to reach it.
2. `mcs sync --all` in that project → expect a warning naming the skipped pack by display name, and the pack absent from `.claude/.mcs-project`.
3. `mcs sync --pack <that pack>` as the only pack → expect a non-zero exit and no changes to the project.
4. Install a pack in a project first, *then* globally, then `mcs sync --all` → expect it to remain configured in the project.
5. Corrupt `~/.mcs/global-state.json` → expect `mcs sync` to fail with a delete-and-retry message. Deleting the file instead → expect sync to proceed normally.

https://claude.ai/code/session_01MkBJdGBUoZ2aRtchjaKXMN