### PR TITLE
ISSUE-374: Make script timeout verdict independent of queue scheduling

### DIFF
--- a/Sources/mcs/ExternalPack/ScriptRunner.swift
+++ b/Sources/mcs/ExternalPack/ScriptRunner.swift
@@ -3,7 +3,11 @@ import os
 
 /// Higher-level wrapper around `ShellRunner` for executing scripts from external packs.
 /// Adds pack-specific concerns: path containment validation, standard environment
-/// variables, timeout enforcement, and executable permission enforcement (auto-chmod).
+/// variables, timeout handling, and executable permission enforcement (auto-chmod).
+///
+/// The timeout is reported reliably but enforced best-effort: `terminate()` sends SIGTERM
+/// to the direct child only, so a script that traps TERM, or whose descendants hold the
+/// output pipes, is waited out in full and only then reported as timed out.
 struct ScriptRunner {
     let shell: any ShellRunning
     let output: CLIOutput
@@ -125,15 +129,11 @@ struct ScriptRunner {
 
     /// Whether a finished process should be reported as having timed out.
     ///
-    /// The killer work item is scheduled on the global concurrent queue, so it is a
-    /// best-effort signal: under load the queue can be starved and the item can fire after
-    /// the process was already reaped, at which point it terminates nothing and records
-    /// nothing. Relying on it alone lets a script that blew its budget be reported as a
-    /// clean success — the timeout silently not applying.
-    ///
-    /// Measured elapsed time cannot be starved, so it is OR-ed in as the authority. This
-    /// adds no false positives: `elapsed >= timeout` means the script really did exceed
-    /// its budget, whether or not anything managed to kill it.
+    /// `elapsed` is the verdict. The killer runs on the global concurrent queue, which can
+    /// be starved: an item that fires after the process was reaped records nothing, so
+    /// deriving the verdict from it reports a script that blew its budget as a success.
+    /// `killerFired` already implies `elapsed >= timeout` and is kept only as redundancy
+    /// against a future change that reorders the deadline and the `start` read.
     static func exceededTimeout(elapsed: TimeInterval, timeout: TimeInterval, killerFired: Bool) -> Bool {
         killerFired || elapsed >= timeout
     }
@@ -185,11 +185,8 @@ struct ScriptRunner {
             throw ScriptError.scriptNotFound("\(executable) (launch failed: \(error.localizedDescription))")
         }
 
-        // Schedule the killer on a background queue. This is best-effort only: the global
-        // concurrent queue can be starved under load, and a work item that fires after the
-        // process has been reaped sees `isRunning == false` and records nothing. The
-        // authoritative verdict is the elapsed measurement below — see `exceededTimeout`.
-        let start = DispatchTime.now()
+        // Best-effort killer — see `exceededTimeout` for why the verdict does not rely on it.
+        let start = ProcessInfo.processInfo.systemUptime
         let killerFired = OSAllocatedUnfairLock(initialState: false)
         let workItem = DispatchWorkItem { [process] in
             if process.isRunning {
@@ -210,8 +207,7 @@ struct ScriptRunner {
         // Cancel timeout if process finished in time
         workItem.cancel()
 
-        let elapsed = TimeInterval(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds)
-            / TimeInterval(NSEC_PER_SEC)
+        let elapsed = ProcessInfo.processInfo.systemUptime - start
         if Self.exceededTimeout(elapsed: elapsed, timeout: timeout, killerFired: killerFired.withLock { $0 }) {
             throw ScriptError.timeout(timeout)
         }

--- a/Sources/mcs/ExternalPack/ScriptRunner.swift
+++ b/Sources/mcs/ExternalPack/ScriptRunner.swift
@@ -123,6 +123,21 @@ struct ScriptRunner {
 
     // MARK: - Internal Helpers
 
+    /// Whether a finished process should be reported as having timed out.
+    ///
+    /// The killer work item is scheduled on the global concurrent queue, so it is a
+    /// best-effort signal: under load the queue can be starved and the item can fire after
+    /// the process was already reaped, at which point it terminates nothing and records
+    /// nothing. Relying on it alone lets a script that blew its budget be reported as a
+    /// clean success — the timeout silently not applying.
+    ///
+    /// Measured elapsed time cannot be starved, so it is OR-ed in as the authority. This
+    /// adds no false positives: `elapsed >= timeout` means the script really did exceed
+    /// its budget, whether or not anything managed to kill it.
+    static func exceededTimeout(elapsed: TimeInterval, timeout: TimeInterval, killerFired: Bool) -> Bool {
+        killerFired || elapsed >= timeout
+    }
+
     /// Ensure the file at the given path has executable permission.
     private func ensureExecutable(at path: String) {
         let fm = FileManager.default
@@ -170,11 +185,15 @@ struct ScriptRunner {
             throw ScriptError.scriptNotFound("\(executable) (launch failed: \(error.localizedDescription))")
         }
 
-        // Schedule timeout on a background queue
-        let timedOut = OSAllocatedUnfairLock(initialState: false)
+        // Schedule the killer on a background queue. This is best-effort only: the global
+        // concurrent queue can be starved under load, and a work item that fires after the
+        // process has been reaped sees `isRunning == false` and records nothing. The
+        // authoritative verdict is the elapsed measurement below — see `exceededTimeout`.
+        let start = DispatchTime.now()
+        let killerFired = OSAllocatedUnfairLock(initialState: false)
         let workItem = DispatchWorkItem { [process] in
             if process.isRunning {
-                timedOut.withLock { $0 = true }
+                killerFired.withLock { $0 = true }
                 process.terminate()
             }
         }
@@ -191,7 +210,9 @@ struct ScriptRunner {
         // Cancel timeout if process finished in time
         workItem.cancel()
 
-        if timedOut.withLock({ $0 }) {
+        let elapsed = TimeInterval(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds)
+            / TimeInterval(NSEC_PER_SEC)
+        if Self.exceededTimeout(elapsed: elapsed, timeout: timeout, killerFired: killerFired.withLock { $0 }) {
             throw ScriptError.timeout(timeout)
         }
 

--- a/Tests/MCSTests/ScriptRunnerTests.swift
+++ b/Tests/MCSTests/ScriptRunnerTests.swift
@@ -313,17 +313,13 @@ struct ScriptRunnerTests {
     @Test(
         "exceededTimeout truth table",
         arguments: [
-            // Killer fired while the process was alive — the normal path.
-            (0.5, 1.0, true, true),
-            // The starvation case: the killer never fired because the queue was starved
-            // and the item ran after the process was reaped. Elapsed time is the only
-            // remaining evidence, and it must still report a timeout.
-            (30.0, 1.0, false, true),
-            // Comfortably inside budget, nothing fired: success.
-            (0.2, 1.0, false, false),
-            // Exactly at the budget counts as exceeded — the script did not finish sooner.
-            (1.0, 1.0, false, true),
-        ] as [(TimeInterval, TimeInterval, Bool, Bool)]
+            (elapsed: 0.5, timeout: 1.0, killerFired: true, expected: true),
+            // The regression: killer starved, elapsed is the only evidence. Unreachable
+            // from an integration test — the global queue cannot be starved on demand.
+            (elapsed: 30.0, timeout: 1.0, killerFired: false, expected: true),
+            (elapsed: 0.2, timeout: 1.0, killerFired: false, expected: false),
+            (elapsed: 1.0, timeout: 1.0, killerFired: false, expected: true),
+        ]
     )
     func exceededTimeoutTruthTable(elapsed: TimeInterval, timeout: TimeInterval, killerFired: Bool, expected: Bool) {
         #expect(
@@ -331,11 +327,10 @@ struct ScriptRunnerTests {
         )
     }
 
-    @Test("A script that outruns its timeout reports a timeout even if nothing killed it")
-    func timeoutReportedWithoutKill() throws {
-        // `trap '' TERM` makes the script ignore the terminate() the killer sends, standing
-        // in for the case where the kill does not take effect. The verdict must not depend
-        // on the kill succeeding.
+    @Test("A script that ignores SIGTERM still reports a timeout")
+    func timeoutReportedWhenKillIgnored() throws {
+        // Still the `killerFired` branch: the flag is set before the kill is attempted,
+        // so trapping TERM never reaches the verdict. Starvation is the truth table's job.
         let tmpDir = try makeTmpDir()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
@@ -343,10 +338,10 @@ struct ScriptRunnerTests {
         try FileManager.default.createDirectory(at: packDir, withIntermediateDirectories: true)
 
         let script = packDir.appendingPathComponent("stubborn.sh")
-        try writeScript("#!/bin/bash\ntrap '' TERM\nsleep 2\necho done", at: script)
+        try writeScript("#!/bin/bash\ntrap '' TERM\nsleep 1\necho done", at: script)
 
-        #expect(throws: ScriptRunner.ScriptError.timeout(1)) {
-            try makeRunner().run(script: script, packPath: packDir, timeout: 1)
+        #expect(throws: ScriptRunner.ScriptError.timeout(0.5)) {
+            try makeRunner().run(script: script, packPath: packDir, timeout: 0.5)
         }
     }
 }

--- a/Tests/MCSTests/ScriptRunnerTests.swift
+++ b/Tests/MCSTests/ScriptRunnerTests.swift
@@ -307,4 +307,46 @@ struct ScriptRunnerTests {
         #expect(result.succeeded)
         #expect(result.stdout == "marker")
     }
+
+    // MARK: - Timeout Verdict
+
+    @Test(
+        "exceededTimeout truth table",
+        arguments: [
+            // Killer fired while the process was alive — the normal path.
+            (0.5, 1.0, true, true),
+            // The starvation case: the killer never fired because the queue was starved
+            // and the item ran after the process was reaped. Elapsed time is the only
+            // remaining evidence, and it must still report a timeout.
+            (30.0, 1.0, false, true),
+            // Comfortably inside budget, nothing fired: success.
+            (0.2, 1.0, false, false),
+            // Exactly at the budget counts as exceeded — the script did not finish sooner.
+            (1.0, 1.0, false, true),
+        ] as [(TimeInterval, TimeInterval, Bool, Bool)]
+    )
+    func exceededTimeoutTruthTable(elapsed: TimeInterval, timeout: TimeInterval, killerFired: Bool, expected: Bool) {
+        #expect(
+            ScriptRunner.exceededTimeout(elapsed: elapsed, timeout: timeout, killerFired: killerFired) == expected
+        )
+    }
+
+    @Test("A script that outruns its timeout reports a timeout even if nothing killed it")
+    func timeoutReportedWithoutKill() throws {
+        // `trap '' TERM` makes the script ignore the terminate() the killer sends, standing
+        // in for the case where the kill does not take effect. The verdict must not depend
+        // on the kill succeeding.
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let packDir = tmpDir.appendingPathComponent("pack")
+        try FileManager.default.createDirectory(at: packDir, withIntermediateDirectories: true)
+
+        let script = packDir.appendingPathComponent("stubborn.sh")
+        try writeScript("#!/bin/bash\ntrap '' TERM\nsleep 2\necho done", at: script)
+
+        #expect(throws: ScriptRunner.ScriptError.timeout(1)) {
+            try makeRunner().run(script: script, packPath: packDir, timeout: 1)
+        }
+    }
 }


### PR DESCRIPTION
## Why

A script's timeout was only reported if a work item scheduled on the global concurrent queue happened to run while the process was still alive. That queue can be starved under load, and an item that fires after the process has been reaped terminates nothing and records nothing — so a script that blew through its budget came back as a clean success, with the timeout silently not applying. A pack script or doctor fix command could therefore run unbounded on a busy machine.

Elapsed time is now measured on a monotonic clock and used as the authority; the work item stays on as a best-effort killer. A measurement cannot be starved. This adds no false positives — exceeding the elapsed budget *is* a timeout, whether or not anything managed to kill the process.

This is also what makes the long-standing intermittent failure of the timeout test go away. That test runs a 30-second script with a 1-second budget: when the killer was starved, the script ran to completion and returned its real output, which is exactly the reported failure (`exitCode: 0, stdout: "done"`). The ~39s duration of failing CI jobs against ~1.1s locally confirmed the script was running its full sleep rather than being killed late.

Closes #374

## Test plan

Automated coverage is the point here — the truth table pins the starvation case (elapsed far past the budget, killer never fired) that previously returned success. To sanity-check by hand:

1. `swift test --filter ScriptRunnerTests` → expect all green, and the whole suite to finish in a couple of seconds rather than tens.
2. Watch the timeout test across a few CI runs on both macOS matrix entries → expect no recurrence of the intermittent failure.