### PR TITLE
ISSUE-373: Regression test: 'mcs update' must not remove both-scope packs

### DIFF
--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -313,47 +313,68 @@ struct UpdateCommand: LockedCommand {
         output: CLIOutput
     ) throws {
         for run in runs {
-            output.header(run.label)
+            try Self.reapplyScope(
+                run,
+                skippedPackIDs: skippedPackIDs,
+                registry: registry,
+                dryRun: dryRun,
+                env: env,
+                shell: shell,
+                output: output
+            )
+        }
+    }
 
-            let packIDs = run.configuredPackIDs.subtracting(skippedPackIDs).sorted()
+    /// Print one scope's header, resolve its configured packs, and converge the scope onto them.
+    ///
+    /// `static` so tests can drive the real re-apply — `UpdateCommand` builds its own
+    /// `Environment()`, so instance paths are not reachable from a sandboxed test bed.
+    /// The list must stay the scope's own configured set: `Configurator.configure` treats it
+    /// as the complete desired state and unconfigures anything missing, with no prompt here.
+    static func reapplyScope(
+        _ run: UpdateScopeResolver.ScopeRun,
+        skippedPackIDs: Set<String>,
+        registry: TechPackRegistry,
+        dryRun: Bool,
+        env: Environment,
+        shell: any ShellRunning,
+        output: CLIOutput,
+        claudeCLI: (any ClaudeCLI)? = nil
+    ) throws {
+        output.header(run.label)
 
-            var packs: [any TechPack] = []
-            var unresolved: [String] = []
-            for packID in packIDs {
-                if let pack = registry.pack(for: packID) {
-                    packs.append(pack)
-                } else {
-                    unresolved.append(packID)
-                }
-            }
-
-            for packID in unresolved {
+        var packs: [any TechPack] = []
+        for packID in run.configuredPackIDs.subtracting(skippedPackIDs).sorted() {
+            guard let pack = registry.pack(for: packID) else {
                 output.warn("  \(packID): tracked in state but missing from pack registry — skipping. Run 'mcs pack add' to restore it.")
-            }
-
-            guard !packs.isEmpty else {
-                output.info("No packs to refresh in this scope.")
                 continue
             }
+            packs.append(pack)
+        }
 
-            let configurator = Configurator(
-                environment: env,
-                output: output,
-                shell: shell,
-                registry: registry,
-                strategy: run.strategy
+        guard !packs.isEmpty else {
+            output.info("No packs to refresh in this scope.")
+            return
+        }
+
+        let configurator = Configurator(
+            environment: env,
+            output: output,
+            shell: shell,
+            registry: registry,
+            strategy: run.strategy,
+            claudeCLI: claudeCLI
+        )
+
+        if dryRun {
+            try configurator.dryRun(packs: packs)
+        } else {
+            try configurator.configure(
+                packs: packs,
+                confirmRemovals: false,
+                excludedComponents: run.excludedComponents,
+                reusePriorValuesSilently: true
             )
-
-            if dryRun {
-                try configurator.dryRun(packs: packs)
-            } else {
-                try configurator.configure(
-                    packs: packs,
-                    confirmRemovals: false,
-                    excludedComponents: run.excludedComponents,
-                    reusePriorValuesSilently: true
-                )
-            }
         }
     }
 

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -204,6 +204,10 @@ private struct LifecycleTestBed {
         try ProjectState(projectRoot: project)
     }
 
+    func globalState() throws -> ProjectState {
+        try ProjectState(stateFile: env.globalStateFile)
+    }
+
     func settingsEnv() throws -> [String: Any] {
         let data = try Data(contentsOf: settingsLocalPath)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
@@ -2256,6 +2260,73 @@ struct GlobalPackBlockingLifecycleTests {
                 output: CLIOutput(colorsEnabled: false)
             )
         }
+    }
+}
+
+// MARK: - Update Re-apply
+
+/// End-to-end coverage for the `mcs update` re-apply phase.
+///
+/// Drives the real `UpdateScopeResolver` and `UpdateCommand.reapplyScope` rather than
+/// `UpdateCommand.perform()`, which builds its own `Environment()` and cannot be pointed
+/// at a sandboxed home.
+struct UpdateReapplyLifecycleTests {
+    @Test(
+        "Both-scope pack survives update re-apply",
+        arguments: [
+            UpdateScopeResolver.Filter.projectOnly, // mcs update --project
+            .all, // bare mcs update: global run, then project run
+        ]
+    )
+    func bothScopePackSurvivesUpdate(filter: UpdateScopeResolver.Filter) throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let hookSource = try bed.makeHookSource(name: "check.sh")
+        let shared = MockTechPack(
+            identifier: "shared-pack",
+            displayName: "Shared Pack",
+            components: [bed.hookComponent(pack: "shared-pack", id: "check", source: hookSource, destination: "check.sh")]
+        )
+        let registry = TechPackRegistry(packs: [shared])
+
+        // Installed in both scopes — the case the global-pack block must never reach.
+        try bed.makeConfigurator(registry: registry)
+            .configure(packs: [shared], confirmRemovals: false)
+        try bed.makeGlobalSyncConfigurator(registry: registry)
+            .configure(packs: [shared], confirmRemovals: false)
+        #expect(try bed.globalState().configuredPacks.contains("shared-pack"))
+
+        // Delete the project copy of the hook so a surviving pack is distinguishable from a
+        // re-apply that never ran: `copyPackFile` is convergent, so `configure` restores it.
+        let projectHook = bed.project.appendingPathComponent(".claude/hooks/shared-pack/check.sh")
+        #expect(FileManager.default.fileExists(atPath: projectHook.path))
+        try FileManager.default.removeItem(at: projectHook)
+
+        let runs = try UpdateScopeResolver(environment: bed.env, output: CLIOutput(colorsEnabled: false))
+            .resolve(filter: filter, projectRoot: bed.project)
+        // An empty run list would pass every assertion below without touching anything.
+        #expect(runs.count == (filter == .all ? 2 : 1))
+
+        for run in runs {
+            try UpdateCommand.reapplyScope(
+                run,
+                skippedPackIDs: [],
+                registry: registry,
+                dryRun: false,
+                env: bed.env,
+                shell: ShellRunner(environment: bed.env),
+                output: CLIOutput(colorsEnabled: false),
+                claudeCLI: bed.mockCLI
+            )
+        }
+
+        // The regression guard: an identity-based filter, or a list sourced from anywhere but
+        // the scope's own state, would have handed `configure` a set missing `shared-pack`
+        // and unconfigured it from the project without a prompt.
+        #expect(try bed.projectState().configuredPacks.contains("shared-pack"))
+        #expect(try bed.globalState().configuredPacks.contains("shared-pack"))
+        #expect(FileManager.default.fileExists(atPath: projectHook.path))
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #373. `mcs update` re-applies each scope's already-configured pack set, so the global-pack block from #370 never reaches it and a pack installed in both scopes survives. That safety was a property of where the update path sourced its list, not something any test asserted, and an earlier `--pack` iteration broke exactly this by filtering the list. This pins it.

While writing the test I found that the same re-apply path drops *skipped* packs (fetch failed, trust declined, missing from registry) from the list, which unconfigures them when a scope holds two or more packs. Filed as #382; not fixed here.

## Changes

- The per-scope re-apply body becomes an internal static helper so a sandboxed test can drive the real resolver → configure chain instead of mirroring it. It takes the whole scope run so the pack list and strategy provably come from the same scope. Production behavior is unchanged.
- New lifecycle test installs a hook pack in both scopes, deletes the project hook, re-applies via `--project` and bare `mcs update`, and asserts the pack is still configured in both scopes and the hook was restored (proving the re-apply ran rather than returned early).

## Test plan

- [x] `swift test` passes locally
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

Manual: with a pack in both scopes, run `mcs update --project` and `mcs update` → expect the pack still listed in the project's `.claude/.mcs-project` and its artifacts intact.

<details>
<summary>Checklist for engine changes</summary>

- [x] Integration tests updated for new features (`LifecycleIntegrationTests` or `DoctorRunnerIntegrationTests`)

</details>

https://claude.ai/code/session_01MkBJdGBUoZ2aRtchjaKXMN
