### PR TITLE
ISSUE-386: Reconcile the pack trust map instead of merging into it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@ swiftlint --fix
 - CI runs both in strict mode (warnings become errors) with GitHub Actions inline annotations
 - SwiftLint excludes `Tests/` — only Sources and Package.swift are linted
 - **Never use `try?` to silently discard errors** — use `do/catch` and surface the error (via `output.warn()`, logging, or propagation). `try?` hides root causes and makes debugging impossible. The only acceptable use is when the absence of a result is the *entire* semantic meaning (e.g., `FileManager.fileExists` alternative)
+- **Comments carry the non-obvious "why", not a narration of the code** — don't restate the line below, don't describe what the code used to do. If the code already says it, delete the comment; if the rationale needs more than a line or two, it belongs in the issue or a memory. State a given rationale once, at the site that owns it, rather than repeating it at every call site
 
 ## Testing
 

--- a/Sources/mcs/Commands/PackCommand.swift
+++ b/Sources/mcs/Commands/PackCommand.swift
@@ -162,16 +162,16 @@ struct AddPack: LockedCommand {
         }
 
         // 5. Trust verification
-        let decision: PackTrustManager.TrustDecision
+        let trustedHashes: [String: String]?
         do {
-            decision = try verifyTrust(manifest: manifest, packPath: fetchResult.localPath, output: ctx.output)
+            trustedHashes = try verifyTrust(manifest: manifest, packPath: fetchResult.localPath, output: ctx.output)
         } catch {
             try? fetcher.remove(packPath: fetchResult.localPath)
             ctx.output.error("Trust verification failed: \(error.localizedDescription)")
             throw ExitCode.failure
         }
 
-        guard decision.approved else {
+        guard let approvedHashes = trustedHashes else {
             try? fetcher.remove(packPath: fetchResult.localPath)
             ctx.output.info("Pack not trusted. No changes made.")
             return
@@ -208,7 +208,7 @@ struct AddPack: LockedCommand {
             commitSHA: fetchResult.commitSHA,
             localPath: manifest.identifier,
             addedAt: ISO8601DateFormatter().string(from: Date()),
-            trustedScriptHashes: decision.scriptHashes,
+            trustedScriptHashes: approvedHashes,
             isLocal: nil
         )
 
@@ -275,15 +275,15 @@ struct AddPack: LockedCommand {
         }
 
         // 4. Trust verification
-        let decision: PackTrustManager.TrustDecision
+        let trustedHashes: [String: String]?
         do {
-            decision = try verifyTrust(manifest: manifest, packPath: path, output: ctx.output)
+            trustedHashes = try verifyTrust(manifest: manifest, packPath: path, output: ctx.output)
         } catch {
             ctx.output.error("Trust verification failed: \(error.localizedDescription)")
             throw ExitCode.failure
         }
 
-        guard decision.approved else {
+        guard let approvedHashes = trustedHashes else {
             ctx.output.info("Pack not trusted. No changes made.")
             return
         }
@@ -298,7 +298,7 @@ struct AddPack: LockedCommand {
             commitSHA: Constants.ExternalPacks.localCommitSentinel,
             localPath: path.path,
             addedAt: ISO8601DateFormatter().string(from: Date()),
-            trustedScriptHashes: decision.scriptHashes,
+            trustedScriptHashes: approvedHashes,
             isLocal: true
         )
 
@@ -376,19 +376,21 @@ struct AddPack: LockedCommand {
         return output.askYesNo("Replace existing pack?", default: false)
     }
 
-    /// Analyze scripts and prompt for trust approval. Throws on failure.
+    /// Analyze scripts and prompt for trust approval, returning the hashes to record.
+    /// `nil` means the user declined. Throws if the scripts cannot be analyzed.
     private func verifyTrust(
         manifest: ExternalPackManifest,
         packPath: URL,
         output: CLIOutput
-    ) throws -> PackTrustManager.TrustDecision {
+    ) throws -> [String: String]? {
         let trustManager = PackTrustManager(output: output)
         let items = try trustManager.analyzeScripts(manifest: manifest, packPath: packPath)
-        return try trustManager.promptForTrust(
+        guard trustManager.promptForTrust(
             manifest: manifest,
             packPath: packPath,
             items: items
-        )
+        ) else { return nil }
+        return try trustManager.computeScriptHashes(items: items, packPath: packPath)
     }
 
     private func displayPackSummary(manifest: ExternalPackManifest, output: CLIOutput) {

--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -133,13 +133,8 @@ struct SyncCommand: LockedCommand {
 
         let lockOps = LockfileOperations(environment: env, output: output, shell: shell)
 
-        // Handle --lock: checkout locked commits, then re-read the packs.
-        //
-        // The caller loaded its registry before this checkout, so it describes the *previous*
-        // commits. A pack that failed to load at the old revision can be perfectly fine at the
-        // locked one — and since `--lock` is the command someone reaches for to restore a known
-        // good state, a stale registry would have the unloadable-pack guard below refuse the very
-        // sync that repairs it.
+        // The caller's registry predates this checkout, so a pack that failed to load at the old
+        // commit may be fine at the locked one — and the guard below would refuse the repair.
         let registry: TechPackRegistry
         if lock {
             try lockOps.checkoutLockedCommits(at: projectPath)
@@ -213,11 +208,7 @@ struct SyncCommand: LockedCommand {
 
     /// Whether this scope must skip convergence because a pack it has configured failed to load.
     /// Warns for each one — see `unloadableConfiguredPacks` for why the whole scope goes.
-    ///
-    /// `static` so tests can drive the real predicate: `perform()` builds its own `Environment()`,
-    /// so the surrounding command is not reachable from a sandboxed test bed and the decision
-    /// cannot be exercised end-to-end. `UpdateReapplyLifecycleTests` covers what convergence would
-    /// have destroyed had the decision gone the other way.
+    /// `static` so tests can reach it: `perform()` builds its own `Environment()`.
     static func scopeIsBlockedByUnloadablePack(
         configured: Set<String>,
         registry: TechPackRegistry,

--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -84,7 +84,14 @@ struct SyncCommand: LockedCommand {
             strategy: GlobalSyncStrategy(environment: env)
         )
 
-        let persistedExclusions = try loadGlobalState(env: env, output: output).allExcludedComponents
+        let globalState = try loadGlobalState(env: env, output: output)
+        let persistedExclusions = globalState.allExcludedComponents
+
+        if scopeIsBlockedByUnloadablePack(
+            configured: globalState.configuredPacks, registry: registry, output: output
+        ) {
+            return
+        }
 
         if all || !pack.isEmpty {
             let packs = try resolvePacks(from: registry, output: output)
@@ -152,6 +159,14 @@ struct SyncCommand: LockedCommand {
 
         let globallyInstalledPacks = try loadGlobalState(env: env, output: output).configuredPacks
 
+        // Before any branch, including --dry-run. Returning here also skips the lockfile work
+        // below, which would otherwise record a state the project was never converged onto.
+        if scopeIsBlockedByUnloadablePack(
+            configured: previouslyConfigured, registry: registry, output: output
+        ) {
+            return
+        }
+
         if all || !pack.isEmpty {
             let packs = try Self.filterGloballyBlocked(
                 resolvePacks(from: registry, output: output),
@@ -184,6 +199,26 @@ struct SyncCommand: LockedCommand {
         case .skip:
             break
         }
+    }
+
+    /// Whether this scope must skip convergence because a pack it has configured failed to load.
+    /// Warns for each one — see `unloadableConfiguredPacks` for why the whole scope goes.
+    private func scopeIsBlockedByUnloadablePack(
+        configured: Set<String>,
+        registry: TechPackRegistry,
+        output: CLIOutput
+    ) -> Bool {
+        let unloadable = registry.unloadableConfiguredPacks(configured: configured)
+        guard !unloadable.isEmpty else { return false }
+
+        output.plain("")
+        for identifier in unloadable {
+            output.warn("Pack '\(identifier)' is configured here but failed to load (see above).")
+        }
+        output.warn("Skipping sync for this scope so the pack's artifacts are left in place.")
+        output.plain("  Run 'mcs pack update <pack>' to re-trust or repair it,")
+        output.plain("  or 'mcs pack remove <pack>' to remove it and its artifacts.")
+        return true
     }
 
     /// Lockfile action at the end of a project sync.

--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -87,7 +87,7 @@ struct SyncCommand: LockedCommand {
         let globalState = try loadGlobalState(env: env, output: output)
         let persistedExclusions = globalState.allExcludedComponents
 
-        if scopeIsBlockedByUnloadablePack(
+        if Self.scopeIsBlockedByUnloadablePack(
             configured: globalState.configuredPacks, registry: registry, output: output
         ) {
             return
@@ -119,7 +119,7 @@ struct SyncCommand: LockedCommand {
         env: Environment,
         output: CLIOutput,
         shell: ShellRunner,
-        registry: TechPackRegistry,
+        registry loadedRegistry: TechPackRegistry,
         config: MCSConfig
     ) throws {
         let projectPath = effectiveTargetURL
@@ -133,9 +133,19 @@ struct SyncCommand: LockedCommand {
 
         let lockOps = LockfileOperations(environment: env, output: output, shell: shell)
 
-        // Handle --lock: checkout locked commits before loading packs
+        // Handle --lock: checkout locked commits, then re-read the packs.
+        //
+        // The caller loaded its registry before this checkout, so it describes the *previous*
+        // commits. A pack that failed to load at the old revision can be perfectly fine at the
+        // locked one — and since `--lock` is the command someone reaches for to restore a known
+        // good state, a stale registry would have the unloadable-pack guard below refuse the very
+        // sync that repairs it.
+        let registry: TechPackRegistry
         if lock {
             try lockOps.checkoutLockedCommits(at: projectPath)
+            registry = TechPackRegistry.loadWithExternalPacks(environment: env, output: output)
+        } else {
+            registry = loadedRegistry
         }
 
         let configurator = Configurator(
@@ -161,7 +171,7 @@ struct SyncCommand: LockedCommand {
 
         // Before any branch, including --dry-run. Returning here also skips the lockfile work
         // below, which would otherwise record a state the project was never converged onto.
-        if scopeIsBlockedByUnloadablePack(
+        if Self.scopeIsBlockedByUnloadablePack(
             configured: previouslyConfigured, registry: registry, output: output
         ) {
             return
@@ -203,7 +213,12 @@ struct SyncCommand: LockedCommand {
 
     /// Whether this scope must skip convergence because a pack it has configured failed to load.
     /// Warns for each one — see `unloadableConfiguredPacks` for why the whole scope goes.
-    private func scopeIsBlockedByUnloadablePack(
+    ///
+    /// `static` so tests can drive the real predicate: `perform()` builds its own `Environment()`,
+    /// so the surrounding command is not reachable from a sandboxed test bed and the decision
+    /// cannot be exercised end-to-end. `UpdateReapplyLifecycleTests` covers what convergence would
+    /// have destroyed had the decision gone the other way.
+    static func scopeIsBlockedByUnloadablePack(
         configured: Set<String>,
         registry: TechPackRegistry,
         output: CLIOutput

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -83,7 +83,7 @@ struct UpdateCommand: LockedCommand {
             output: output
         )
 
-        try runReapplyPhase(
+        let blockedProjects = try runReapplyPhase(
             runs: runs,
             skippedPackIDs: updatePhase.skipped,
             registry: techPackRegistry,
@@ -92,7 +92,9 @@ struct UpdateCommand: LockedCommand {
             output: output
         )
 
-        try runLockfilePhase(runs: runs, env: env, shell: shell, output: output)
+        try runLockfilePhase(
+            runs: runs, blockedProjects: blockedProjects, env: env, shell: shell, output: output
+        )
 
         if !dryRun {
             UpdateChecker.checkAndPrint(env: env, shell: shell, output: output)
@@ -304,6 +306,8 @@ struct UpdateCommand: LockedCommand {
         let attempted: Int
     }
 
+    /// Converge every scope, returning the project paths that were left untouched so the lockfile
+    /// phase does not record commits whose artifacts were never applied.
     private func runReapplyPhase(
         runs: [UpdateScopeResolver.ScopeRun],
         skippedPackIDs: Set<String>,
@@ -311,9 +315,10 @@ struct UpdateCommand: LockedCommand {
         env: Environment,
         shell: ShellRunner,
         output: CLIOutput
-    ) throws {
+    ) throws -> Set<URL> {
+        var blockedProjects: Set<URL> = []
         for run in runs {
-            try Self.reapplyScope(
+            let blocked = try Self.reapplyScope(
                 run,
                 skippedPackIDs: skippedPackIDs,
                 registry: registry,
@@ -322,10 +327,16 @@ struct UpdateCommand: LockedCommand {
                 shell: shell,
                 output: output
             )
+            if blocked, let projectPath = run.projectPath {
+                blockedProjects.insert(projectPath)
+            }
         }
+        return blockedProjects
     }
 
     /// Print one scope's header, resolve its configured packs, and converge the scope onto them.
+    /// Returns `true` when the scope was left untouched, so the caller can keep the lockfile in
+    /// step with what was actually applied.
     ///
     /// `static` so tests can drive the real re-apply — `UpdateCommand` builds its own
     /// `Environment()`, so instance paths are not reachable from a sandboxed test bed.
@@ -340,37 +351,43 @@ struct UpdateCommand: LockedCommand {
         shell: any ShellRunning,
         output: CLIOutput,
         claudeCLI: (any ClaudeCLI)? = nil
-    ) throws {
+    ) throws -> Bool {
         output.header(run.label)
 
-        // A pack that was skipped or failed to load makes the *whole* scope skip: `configure`
-        // treats its pack list as the complete desired state, so subtracting one silently
-        // unconfigures it (#382).
-        let notUpdated = run.configuredPackIDs.intersection(skippedPackIDs).sorted()
-        let unloadable = registry.unloadableConfiguredPacks(configured: run.configuredPackIDs)
-        if !notUpdated.isEmpty || !unloadable.isEmpty {
-            for identifier in notUpdated {
+        // Any configured pack this run cannot produce blocks the *whole* scope: `configure` treats
+        // its pack list as the complete desired state, so resolving a shorter list silently
+        // unconfigures the remainder (#382).
+        //
+        // Unlike `mcs sync`, nothing here is a deselection — the desired state *is* the recorded
+        // state — so a pack missing from `registry.yaml` blocks too rather than being converged
+        // away. Reporting is per cause because the remedies differ.
+        let notUpdated = run.configuredPackIDs.intersection(skippedPackIDs)
+        let unloadable = Set(registry.unloadableConfiguredPacks(configured: run.configuredPackIDs))
+            .subtracting(notUpdated)
+        let unregistered = run.configuredPackIDs
+            .subtracting(registry.availablePackIDs)
+            .subtracting(notUpdated)
+            .subtracting(unloadable)
+
+        if !notUpdated.isEmpty || !unloadable.isEmpty || !unregistered.isEmpty {
+            for identifier in notUpdated.sorted() {
                 output.warn("  \(identifier): update did not complete — re-run 'mcs update'.")
             }
-            for identifier in unloadable {
+            for identifier in unloadable.sorted() {
                 output.warn("  \(identifier): failed to load — run 'mcs pack update \(identifier)'.")
             }
+            for identifier in unregistered.sorted() {
+                output.warn("  \(identifier): tracked in state but missing from the pack registry — run 'mcs pack add' to restore it.")
+            }
             output.warn("  Skipping re-apply for this scope so no artifacts are removed.")
-            return
+            return true
         }
 
-        var packs: [any TechPack] = []
-        for packID in run.configuredPackIDs.sorted() {
-            guard let pack = registry.pack(for: packID) else {
-                output.warn("  \(packID): tracked in state but missing from pack registry — skipping. Run 'mcs pack add' to restore it.")
-                continue
-            }
-            packs.append(pack)
-        }
+        let packs = run.configuredPackIDs.sorted().compactMap { registry.pack(for: $0) }
 
         guard !packs.isEmpty else {
             output.info("No packs to refresh in this scope.")
-            return
+            return true
         }
 
         let configurator = Configurator(
@@ -392,10 +409,12 @@ struct UpdateCommand: LockedCommand {
                 reusePriorValuesSilently: true
             )
         }
+        return false
     }
 
     private func runLockfilePhase(
         runs: [UpdateScopeResolver.ScopeRun],
+        blockedProjects: Set<URL>,
         env: Environment,
         shell: ShellRunner,
         output: CLIOutput
@@ -409,8 +428,15 @@ struct UpdateCommand: LockedCommand {
             guard let projectPath = run.projectPath else { continue }
 
             if config.isLockfileGenerationEnabled {
-                try lockOps.writeLockfile(at: projectPath)
+                // The registry already holds the new SHAs, so writing a lockfile for a scope that
+                // never converged would describe a configuration that is not on disk.
+                if blockedProjects.contains(projectPath) {
+                    output.warn("Skipped mcs.lock.yaml for \(run.label) — the scope did not converge.")
+                } else {
+                    try lockOps.writeLockfile(at: projectPath)
+                }
             } else if config.isLockfileGenerationUnset {
+                // Read-only, and its drift warning is accurate either way.
                 try lockOps.reportDrift(at: projectPath)
             }
         }

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -343,8 +343,24 @@ struct UpdateCommand: LockedCommand {
     ) throws {
         output.header(run.label)
 
+        // A pack that was skipped or failed to load makes the *whole* scope skip: `configure`
+        // treats its pack list as the complete desired state, so subtracting one silently
+        // unconfigures it (#382).
+        let notUpdated = run.configuredPackIDs.intersection(skippedPackIDs).sorted()
+        let unloadable = registry.unloadableConfiguredPacks(configured: run.configuredPackIDs)
+        if !notUpdated.isEmpty || !unloadable.isEmpty {
+            for identifier in notUpdated {
+                output.warn("  \(identifier): update did not complete — re-run 'mcs update'.")
+            }
+            for identifier in unloadable {
+                output.warn("  \(identifier): failed to load — run 'mcs pack update \(identifier)'.")
+            }
+            output.warn("  Skipping re-apply for this scope so no artifacts are removed.")
+            return
+        }
+
         var packs: [any TechPack] = []
-        for packID in run.configuredPackIDs.subtracting(skippedPackIDs).sorted() {
+        for packID in run.configuredPackIDs.sorted() {
             guard let pack = registry.pack(for: packID) else {
                 output.warn("  \(packID): tracked in state but missing from pack registry — skipping. Run 'mcs pack add' to restore it.")
                 continue

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -306,8 +306,8 @@ struct UpdateCommand: LockedCommand {
         let attempted: Int
     }
 
-    /// Converge every scope, returning the project paths that were left untouched so the lockfile
-    /// phase does not record commits whose artifacts were never applied.
+    /// Converge every scope, returning the project paths left untouched so the lockfile phase
+    /// does not record commits whose artifacts were never applied.
     private func runReapplyPhase(
         runs: [UpdateScopeResolver.ScopeRun],
         skippedPackIDs: Set<String>,
@@ -335,8 +335,7 @@ struct UpdateCommand: LockedCommand {
     }
 
     /// Print one scope's header, resolve its configured packs, and converge the scope onto them.
-    /// Returns `true` when the scope was left untouched, so the caller can keep the lockfile in
-    /// step with what was actually applied.
+    /// Returns `true` when the scope was left untouched.
     ///
     /// `static` so tests can drive the real re-apply — `UpdateCommand` builds its own
     /// `Environment()`, so instance paths are not reachable from a sandboxed test bed.
@@ -354,13 +353,9 @@ struct UpdateCommand: LockedCommand {
     ) throws -> Bool {
         output.header(run.label)
 
-        // Any configured pack this run cannot produce blocks the *whole* scope: `configure` treats
-        // its pack list as the complete desired state, so resolving a shorter list silently
-        // unconfigures the remainder (#382).
-        //
-        // Unlike `mcs sync`, nothing here is a deselection — the desired state *is* the recorded
-        // state — so a pack missing from `registry.yaml` blocks too rather than being converged
-        // away. Reporting is per cause because the remedies differ.
+        // Any pack this run cannot produce blocks the *whole* scope: `configure` treats its list
+        // as the complete desired state, so a shorter one silently unconfigures the rest (#382).
+        // Nothing here is a deselection — unlike `mcs sync` — so an unregistered pack blocks too.
         let notUpdated = run.configuredPackIDs.intersection(skippedPackIDs)
         let unloadable = Set(registry.unloadableConfiguredPacks(configured: run.configuredPackIDs))
             .subtracting(notUpdated)
@@ -428,15 +423,14 @@ struct UpdateCommand: LockedCommand {
             guard let projectPath = run.projectPath else { continue }
 
             if config.isLockfileGenerationEnabled {
-                // The registry already holds the new SHAs, so writing a lockfile for a scope that
-                // never converged would describe a configuration that is not on disk.
+                // The registry already holds the new SHAs, so a lockfile for a scope that never
+                // converged would describe a configuration that is not on disk.
                 if blockedProjects.contains(projectPath) {
                     output.warn("Skipped mcs.lock.yaml for \(run.label) — the scope did not converge.")
                 } else {
                     try lockOps.writeLockfile(at: projectPath)
                 }
             } else if config.isLockfileGenerationUnset {
-                // Read-only, and its drift warning is accurate either way.
                 try lockOps.reportDrift(at: projectPath)
             }
         }

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -311,9 +311,17 @@ struct UpdateChecker {
         )
         guard fetchResult.succeeded else { return .unknown(.fetchFailed) }
 
+        // Diff from the *registry* baseline, not from `HEAD`. Suppression advances
+        // `entry.commitSHA` to the remote SHA, so the classified range must be the range the
+        // caller compared. When the checkout sits ahead of the registry — advanced by an update
+        // whose trust was then declined — `HEAD..remote` is empty, empty classifies as suppressed,
+        // and advancing the baseline would erase the mismatch that lets `PackUpdater` re-prompt
+        // for trust, stranding the pack. `commitSHA` comes from `registry.yaml`, so validate it
+        // like `ref` above.
+        guard isValidGitRef(entry.commitSHA) else { return .unknown(.fetchFailed) }
         let diffResult = shell.run(
             environment.gitPath,
-            arguments: ["diff", "--name-only", "HEAD", diffTarget],
+            arguments: ["diff", "--name-only", entry.commitSHA, diffTarget],
             workingDirectory: workDir,
             additionalEnvironment: Self.gitNoPromptEnv
         )

--- a/Sources/mcs/Doctor/DoctorRunner.swift
+++ b/Sources/mcs/Doctor/DoctorRunner.swift
@@ -180,13 +180,13 @@ struct DoctorRunner {
         var allPackIDs = Set<String>()
         let availablePacks = registry.availablePacks
 
-        // Warn about unregistered pack IDs from --pack filter
-        if packFilter != nil {
-            let availableIDs = Set(availablePacks.map(\.identifier))
-            for scope in scopes {
-                for id in scope.packIDs.sorted() where !availableIDs.contains(id) {
-                    output.warn("Pack \"\(id)\" is not registered \u{2014} no checks will be run for it")
-                }
+        // Warn for pack IDs that produced no pack — unconditional, not just under `--pack`: the
+        // scope line above lists the ID either way, so a pack that failed to load would otherwise
+        // be skipped in silence. The cause is not determined here, so the message names both.
+        let availableIDs = registry.availablePackIDs
+        for scope in scopes {
+            for id in scope.packIDs.sorted() where !availableIDs.contains(id) {
+                output.warn("Pack \"\(id)\" is not registered or failed to load \u{2014} no checks will be run for it")
             }
         }
 

--- a/Sources/mcs/ExternalPack/ExternalPackLoader.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackLoader.swift
@@ -15,6 +15,13 @@ struct ExternalPackLoader {
         case incompatibleVersion(pack: String, required: String, current: String)
         case localCheckoutMissing(identifier: String, path: String)
         case referencedFilesMissing(identifier: String, files: [String])
+        /// Scripts the pack would execute do not match what the user approved. A distinct case
+        /// because `loadAll` routes it to a security warning — matching on the message text
+        /// instead made that routing depend on the wording staying intact.
+        case trustVerificationFailed(
+            identifier: String,
+            offenders: [String: PackTrustManager.TrustMismatch]
+        )
 
         var errorDescription: String? {
             switch self {
@@ -28,6 +35,16 @@ struct ExternalPackLoader {
                 "Pack '\(id)' checkout missing at '\(path)'"
             case let .referencedFilesMissing(id, files):
                 "Pack '\(id)' references missing files: \(files.joined(separator: ", "))"
+            case let .trustVerificationFailed(id, offenders):
+                "Pack '\(id)' has unapproved scripts: "
+                    + offenders.keys.sorted().map { path in
+                        switch offenders[path] {
+                        case .neverTrusted: "\(path) (never trusted)"
+                        case let .unreadable(reason): "\(path) (unreadable: \(reason))"
+                        default: "\(path) (modified)"
+                        }
+                    }.joined(separator: ", ")
+                    + ". Run 'mcs pack update \(id)' to re-trust."
             }
         }
     }
@@ -193,8 +210,8 @@ struct ExternalPackLoader {
 
     /// Check if a load error is a trust verification failure.
     private func isTrustFailure(_ error: LoadError) -> Bool {
-        if case let .invalidManifest(_, reason) = error {
-            return reason.contains("Trusted scripts modified")
+        if case .trustVerificationFailed = error {
+            return true
         }
         return false
     }
@@ -227,15 +244,17 @@ struct ExternalPackLoader {
         // Skip trust verification for local packs — scripts change during development
         if !entry.isLocalPack {
             let trustManager = PackTrustManager(output: CLIOutput())
-            let modified = trustManager.verifyTrust(
+            // Analyzing reads script contents, so an unreadable script surfaces as a plain load
+            // failure rather than the security warning below.
+            let offenders = try trustManager.verifyTrust(
                 trustedHashes: entry.trustedScriptHashes,
-                packPath: packPath
+                packPath: packPath,
+                manifest: manifest
             )
-            if !modified.isEmpty {
-                throw LoadError.invalidManifest(
+            if !offenders.isEmpty {
+                throw LoadError.trustVerificationFailed(
                     identifier: entry.identifier,
-                    reason:
-                    "Trusted scripts modified: \(modified.joined(separator: ", ")). Run 'mcs pack update \(entry.identifier)' to re-trust."
+                    offenders: offenders
                 )
             }
         }

--- a/Sources/mcs/ExternalPack/PackTrustManager.swift
+++ b/Sources/mcs/ExternalPack/PackTrustManager.swift
@@ -248,12 +248,10 @@ struct PackTrustManager {
 
         for item in try analyzeScripts(manifest: manifest, packPath: packPath) {
             guard let relativePath = item.relativePath else {
-                // A doctor check's `command`/`fixScript` is overloaded — a script path or an
-                // inline command — and analysis can only tell them apart by whether the file
-                // exists, so deleting a trusted script silently reclassifies it as inline and it
-                // would slip past the exemption above. A stored hash under the declared value
-                // itself proves it was trusted as a file, since inline items are keyed
-                // `inline:<hash>`: the file is gone, which is a mismatch, not an exemption.
+                // A doctor `command`/`fixScript` is a path or an inline command, told apart only
+                // by whether the file exists — so deleting a trusted script reclassifies it as
+                // inline. Inline items are keyed `inline:<hash>`, so a stored hash under the value
+                // itself means it was trusted as a file that is now gone.
                 if trustedHashes[item.content] != nil {
                     offenders[item.content] = .mismatched
                 }

--- a/Sources/mcs/ExternalPack/PackTrustManager.swift
+++ b/Sources/mcs/ExternalPack/PackTrustManager.swift
@@ -1,15 +1,9 @@
-import CryptoKit
 import Foundation
 
 /// Manages the trust lifecycle for external packs — analyzing executable content,
 /// prompting for user approval, and verifying script integrity before execution.
 struct PackTrustManager {
     let output: CLIOutput
-
-    struct TrustDecision {
-        let approved: Bool
-        let scriptHashes: [String: String] // relativePath -> SHA-256
-    }
 
     // MARK: - Analyze
 
@@ -134,14 +128,17 @@ struct PackTrustManager {
     // MARK: - Prompt
 
     /// Display all trustable items and prompt the user for approval.
-    /// If the pack has no executable content, trust is implicit (returns approved with empty hashes).
+    /// A pack with no executable content is trusted implicitly.
+    ///
+    /// Callers that need the approved hashes compute them from the same items via
+    /// `computeScriptHashes` — returning them here produced a map the update path discarded.
     func promptForTrust(
         manifest: ExternalPackManifest,
-        packPath: URL,
+        packPath _: URL,
         items: [TrustableItem]
-    ) throws -> TrustDecision {
+    ) -> Bool {
         if items.isEmpty {
-            return TrustDecision(approved: true, scriptHashes: [:])
+            return true
         }
 
         output.plain("")
@@ -219,90 +216,84 @@ struct PackTrustManager {
         }
 
         output.plain("")
-        let approved = output.askYesNo("Trust this pack?", default: false)
-
-        if approved {
-            let hashes = try computeScriptHashes(items: items, packPath: packPath)
-            return TrustDecision(approved: true, scriptHashes: hashes)
-        }
-
-        return TrustDecision(approved: false, scriptHashes: [:])
+        return output.askYesNo("Trust this pack?", default: false)
     }
 
     // MARK: - Verify
 
-    /// Verify that trusted scripts haven't changed since they were approved.
-    /// Returns relative paths of scripts that have been modified.
-    func verifyTrust(
-        trustedHashes: [String: String],
-        packPath: URL
-    ) -> [String] {
-        var modified: [String] = []
-        let fm = FileManager.default
-
-        for (relativePath, expectedHash) in trustedHashes {
-            // Skip synthetic keys for inline commands (they have no file on disk)
-            if relativePath.hasPrefix("inline:") {
-                continue
-            }
-
-            let fileURL = packPath.appendingPathComponent(relativePath)
-
-            guard fm.fileExists(atPath: fileURL.path) else {
-                modified.append(relativePath)
-                continue
-            }
-
-            do {
-                let currentHash = try FileHasher.sha256(of: fileURL)
-                if currentHash != expectedHash {
-                    modified.append(relativePath)
-                }
-            } catch {
-                // I/O error is distinct from tampering — surface the cause
-                modified.append("\(relativePath) (unreadable: \(error.localizedDescription))")
-            }
-        }
-
-        return modified.sorted()
+    /// Why a trustable item fails to match the approved set, or `nil` when it verifies.
+    enum TrustMismatch: Equatable {
+        case neverTrusted // No stored hash for this item
+        case mismatched // Content disagrees with the stored hash, or the file is gone
+        case unreadable(String) // Present, but could not be hashed
     }
 
-    /// Check if an update introduces new scripts not in the trusted set.
-    /// Returns items for scripts that are new or have changed.
-    func detectNewScripts(
-        currentHashes: [String: String],
-        updatedPackPath: URL,
+    /// Scripts the pack will execute that the user has not approved, keyed by pack-relative path.
+    ///
+    /// Walks forward from the manifest's analyzed items, never over the stored hash keys: a key
+    /// left behind for a file the pack no longer references says nothing about what will execute,
+    /// and a referenced script with *no* stored hash must not go unchecked.
+    ///
+    /// Inline items are exempt as a **bounded migration**, not because they are safe: a trust map
+    /// written before inline hashing has no synthetic keys, so enforcing them would refuse every
+    /// such pack at load. The first `mcs pack update` writes a complete map, after which they
+    /// could be enforced. Until then an inline `shell:` edited in the local checkout is not caught
+    /// here.
+    func verifyTrust(
+        trustedHashes: [String: String],
+        packPath: URL,
         manifest: ExternalPackManifest
-    ) throws -> [TrustableItem] {
-        let allItems = try analyzeScripts(manifest: manifest, packPath: updatedPackPath)
+    ) throws -> [String: TrustMismatch] {
+        var offenders: [String: TrustMismatch] = [:]
 
-        // Filter to items that are new or changed compared to trusted hashes
-        return allItems.filter { item in
-            guard let relativePath = item.relativePath else {
-                // Inline command — check synthetic hash against trusted set
-                let contentData = Data(item.content.utf8)
-                let hash = SHA256.hash(data: contentData)
-                    .map { String(format: "%02x", $0) }.joined()
-                let syntheticKey = Self.syntheticKey(for: item)
-                if let trustedHash = currentHashes[syntheticKey] {
-                    return trustedHash != hash // Changed since last trust
-                }
+        for item in try analyzeScripts(manifest: manifest, packPath: packPath) {
+            guard let relativePath = item.relativePath,
+                  let reason = mismatch(for: item, against: trustedHashes, packPath: packPath)
+            else { continue }
+            offenders[relativePath] = reason
+        }
+
+        return offenders
+    }
+
+    /// Filter analyzed items down to those needing user approval.
+    func newOrChanged(
+        in items: [TrustableItem],
+        against currentHashes: [String: String],
+        packPath: URL
+    ) -> [TrustableItem] {
+        items.filter { mismatch(for: $0, against: currentHashes, packPath: packPath) != nil }
+    }
+
+    /// The one comparison rule behind both load-time verification and update-time change detection.
+    private func mismatch(
+        for item: TrustableItem,
+        against trustedHashes: [String: String],
+        packPath: URL
+    ) -> TrustMismatch? {
+        guard let relativePath = item.relativePath else {
+            guard let trustedHash = trustedHashes[Self.syntheticKey(for: item)] else {
                 // Never trusted before. An item that merely restates the behaviour a pack already
                 // had needs no prompt — that is how packs predating hook-interpreter tracking stay
                 // quiet on their first update. Anything else is genuinely new.
-                return !item.representsDefaultBehavior
+                return item.representsDefaultBehavior ? nil : .neverTrusted
             }
-            guard let trustedHash = currentHashes[relativePath] else {
-                return true // New script not in trusted set
-            }
-            let fileURL = updatedPackPath.appendingPathComponent(relativePath)
-            let hash: String
-            do {
-                hash = try FileHasher.sha256(of: fileURL)
-            } catch {
-                return true // Can't verify — flag for re-trust
-            }
-            return hash != trustedHash // Changed since last trust
+            return trustedHash == Self.contentHash(of: item.content) ? nil : .mismatched
+        }
+
+        guard let trustedHash = trustedHashes[relativePath] else {
+            return .neverTrusted
+        }
+        // A deleted file reads as `.mismatched` rather than `.unreadable`, so the message stays
+        // about trust instead of quoting a "no such file" error.
+        let fileURL = packPath.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return .mismatched
+        }
+        do {
+            return try FileHasher.sha256(of: fileURL) == trustedHash ? nil : .mismatched
+        } catch {
+            return .unreadable(error.localizedDescription)
         }
     }
 
@@ -313,10 +304,12 @@ struct PackTrustManager {
     /// Note: Swift's `String.hashValue` is randomized per-process (SE-0206) and must not
     /// be used for persistent keys.
     private static func syntheticKey(for item: TrustableItem) -> String {
-        let descData = Data(item.description.utf8)
-        let descHash = SHA256.hash(data: descData)
-            .map { String(format: "%02x", $0) }.joined()
-        return "inline:\(descHash)"
+        "inline:\(contentHash(of: item.description))"
+    }
+
+    /// Hex-encoded SHA-256 of a string.
+    private static func contentHash(of content: String) -> String {
+        FileHasher.sha256(data: Data(content.utf8))
     }
 
     private func readFileContent(at url: URL, fallback: String) throws -> String {
@@ -398,7 +391,6 @@ struct PackTrustManager {
         return items
     }
 
-    /// Compute SHA-256 hashes for all trustable items — both script files and inline commands.
     /// Hashes for a set of trustable items — file hash by relative path, content hash under a
     /// synthetic key for inline items.
     ///
@@ -419,11 +411,7 @@ struct PackTrustManager {
                 }
             } else {
                 // Inline command — hash the content with a deterministic synthetic key
-                let contentData = Data(item.content.utf8)
-                let hash = SHA256.hash(data: contentData)
-                    .map { String(format: "%02x", $0) }.joined()
-                let syntheticKey = Self.syntheticKey(for: item)
-                hashes[syntheticKey] = hash
+                hashes[Self.syntheticKey(for: item)] = Self.contentHash(of: item.content)
             }
         }
 

--- a/Sources/mcs/ExternalPack/PackTrustManager.swift
+++ b/Sources/mcs/ExternalPack/PackTrustManager.swift
@@ -346,7 +346,9 @@ struct PackTrustManager {
         }
 
         if check.type == .shellScript, let command = check.command {
-            // The command field may be a script file path or inline command
+            // `shellScript` always resolves `command` as a pack-relative path — inline commands
+            // belong in `commandExists`/`fixCommand` — so an absent file means a broken pack, not
+            // an inline form. It is still tracked below so the declared string gets reviewed.
             let scriptFile = packPath.appendingPathComponent(command)
             if FileManager.default.fileExists(atPath: scriptFile.path) {
                 let fileContent = try String(contentsOf: scriptFile, encoding: .utf8)

--- a/Sources/mcs/ExternalPack/PackTrustManager.swift
+++ b/Sources/mcs/ExternalPack/PackTrustManager.swift
@@ -247,8 +247,19 @@ struct PackTrustManager {
         var offenders: [String: TrustMismatch] = [:]
 
         for item in try analyzeScripts(manifest: manifest, packPath: packPath) {
-            guard let relativePath = item.relativePath,
-                  let reason = mismatch(for: item, against: trustedHashes, packPath: packPath)
+            guard let relativePath = item.relativePath else {
+                // A doctor check's `command`/`fixScript` is overloaded — a script path or an
+                // inline command — and analysis can only tell them apart by whether the file
+                // exists, so deleting a trusted script silently reclassifies it as inline and it
+                // would slip past the exemption above. A stored hash under the declared value
+                // itself proves it was trusted as a file, since inline items are keyed
+                // `inline:<hash>`: the file is gone, which is a mismatch, not an exemption.
+                if trustedHashes[item.content] != nil {
+                    offenders[item.content] = .mismatched
+                }
+                continue
+            }
+            guard let reason = mismatch(for: item, against: trustedHashes, packPath: packPath)
             else { continue }
             offenders[relativePath] = reason
         }

--- a/Sources/mcs/Sync/PackUpdater.swift
+++ b/Sources/mcs/Sync/PackUpdater.swift
@@ -62,6 +62,16 @@ struct PackUpdater {
                     beforeSnapshot: beforeSnapshot
                 )
             }
+            // Same commit, but recorded trust may still not describe what is on disk — a registry
+            // SHA advanced without re-trust, or a map naming files a past update renamed. Without
+            // this the loader's "run 'mcs pack update' to re-trust" advice is a dead end: refused
+            // at load, "already up to date" forever.
+            if trustNeedsRenewal(entry: entry, packPath: packPath, snapshot: beforeSnapshot) {
+                return validateAndTrust(
+                    entry: entry, packPath: packPath, registry: registry, commitSHA: diskSHA,
+                    beforeSnapshot: beforeSnapshot
+                )
+            }
             return .alreadyUpToDate
         }
 
@@ -90,6 +100,30 @@ struct PackUpdater {
         }
     }
 
+    /// Whether recorded trust still covers what is on disk at the current commit. Covers inline
+    /// items too, so a stale `shell:` or MCP-command hash is caught, not just a changed file.
+    ///
+    /// Reuses the pre-fetch snapshot's manifest: this only runs when the fetch moved nothing, so
+    /// the tree it described is the tree on disk. A `nil` snapshot means its `validate` threw, and
+    /// `validateAndTrust` is left to report the real error rather than this claiming trust is fine.
+    private func trustNeedsRenewal(
+        entry: PackRegistryFile.PackEntry,
+        packPath: URL,
+        snapshot: PackSnapshot?
+    ) -> Bool {
+        guard let manifest = snapshot?.manifest else { return true }
+        do {
+            let items = try trustManager.analyzeScripts(manifest: manifest, packPath: packPath)
+            return !trustManager.newOrChanged(
+                in: items,
+                against: entry.trustedScriptHashes,
+                packPath: packPath
+            ).isEmpty
+        } catch {
+            return true
+        }
+    }
+
     /// Validate the manifest, detect new scripts, prompt for trust, and build an updated entry.
     private func validateAndTrust(
         entry: PackRegistryFile.PackEntry,
@@ -106,36 +140,42 @@ struct PackUpdater {
             return .manifestInvalid(underlying: error)
         }
 
-        var scriptHashes = entry.trustedScriptHashes
-        let newItems: [TrustableItem]
+        let allItems: [TrustableItem]
         do {
-            newItems = try trustManager.detectNewScripts(
-                currentHashes: entry.trustedScriptHashes,
-                updatedPackPath: packPath,
-                manifest: manifest
-            )
+            allItems = try trustManager.analyzeScripts(manifest: manifest, packPath: packPath)
         } catch {
             return .internalError(underlying: error)
         }
+        let newItems = trustManager.newOrChanged(
+            in: allItems,
+            against: entry.trustedScriptHashes,
+            packPath: packPath
+        )
 
         if !newItems.isEmpty {
             output.warn("\(entry.displayName) has new or modified scripts:")
-            let decision: PackTrustManager.TrustDecision
-            do {
-                decision = try trustManager.promptForTrust(
-                    manifest: manifest,
-                    packPath: packPath,
-                    items: newItems
-                )
-            } catch {
-                return .internalError(underlying: error)
-            }
-            guard decision.approved else {
+            guard trustManager.promptForTrust(
+                manifest: manifest,
+                packPath: packPath,
+                items: newItems
+            ) else {
                 return .trustDeclined
             }
-            for (path, hash) in decision.scriptHashes {
-                scriptHashes[path] = hash
-            }
+        }
+
+        // Rebuild the map from the analyzed items instead of merging into the old one: merging left
+        // a key behind for every file an update renamed or deleted, and `verifyTrust` then refused
+        // the pack over files it no longer shipped. Unconditional even when nothing prompted — a
+        // commit that only *removes* a script produces no new items, and that is exactly the
+        // orphan case.
+        //
+        // This can never silently trust changed content: any item whose hash differs is in
+        // `newItems`, hence already prompted.
+        let scriptHashes: [String: String]
+        do {
+            scriptHashes = try trustManager.computeScriptHashes(items: allItems, packPath: packPath)
+        } catch {
+            return .internalError(underlying: error)
         }
 
         let updatedEntry = PackRegistryFile.PackEntry(

--- a/Sources/mcs/TechPack/TechPackRegistry.swift
+++ b/Sources/mcs/TechPack/TechPackRegistry.swift
@@ -6,13 +6,23 @@ struct TechPackRegistry {
 
     private let packs: [any TechPack]
 
-    init(packs: [any TechPack] = []) {
+    /// Identifiers present in `registry.yaml`, whether or not they produced a pack. A pack in
+    /// this set but absent from `packs` failed to load; one in neither is not installed at all.
+    private let registeredPackIDs: Set<String>
+
+    init(packs: [any TechPack] = [], registeredPackIDs: Set<String>? = nil) {
         self.packs = packs
+        self.registeredPackIDs = registeredPackIDs ?? Set(packs.map(\.identifier))
     }
 
     /// All registered packs sorted by identifier.
     var availablePacks: [any TechPack] {
         packs.sorted { $0.identifier < $1.identifier }
+    }
+
+    /// Identifiers of the packs that loaded. Unsorted — callers wanting order sort at the edge.
+    var availablePackIDs: Set<String> {
+        Set(packs.map(\.identifier))
     }
 
     /// Find a pack by identifier.
@@ -46,9 +56,32 @@ struct TechPackRegistry {
         let packRegistryFile = PackRegistryFile(path: environment.packsRegistry)
         let loader = ExternalPackLoader(environment: environment, registry: packRegistryFile)
         let adapters = loader.loadAll(output: output)
-        if adapters.isEmpty {
-            return .shared
+
+        // Registered identifiers are read even when nothing loaded, so callers can still tell a
+        // pack that failed to load from one that was never installed.
+        var registered: Set<String>
+        do {
+            registered = try Set(packRegistryFile.load().packs.map(\.identifier))
+        } catch {
+            output.warn("Could not read the pack registry: \(error.localizedDescription)")
+            registered = Set(adapters.map(\.identifier))
         }
-        return TechPackRegistry(packs: adapters)
+
+        return TechPackRegistry(packs: adapters, registeredPackIDs: registered)
+    }
+
+    /// Packs a scope has configured that are registered but failed to load — an entry exists in
+    /// `registry.yaml`, yet no adapter came back (trust verification, invalid manifest, missing
+    /// checkout, incompatible `minMCSVersion`; `loadAll` has already printed which).
+    ///
+    /// Callers must not hand these to `Configurator.configure`. It treats its pack list as the
+    /// complete desired state and unconfigures whatever is missing, so a pack that merely failed
+    /// to load reads as "the user deselected this" and has its artifacts deleted.
+    ///
+    /// A pack with **no** registry entry is deliberately excluded: it is genuinely absent, so
+    /// converging it away is the intended repair rather than data loss. (It would also be
+    /// unremovable otherwise — `mcs pack remove` refuses an identifier missing from the registry.)
+    func unloadableConfiguredPacks(configured: Set<String>) -> [String] {
+        configured.intersection(registeredPackIDs).subtracting(availablePackIDs).sorted()
     }
 }

--- a/Tests/MCSTests/DoctorRunnerIntegrationTests.swift
+++ b/Tests/MCSTests/DoctorRunnerIntegrationTests.swift
@@ -586,4 +586,31 @@ struct DoctorSummaryWarningCountTests {
         #expect(spaced.passed == tight.passed)
         #expect(spaced.issues == tight.issues)
     }
+
+    /// A bare `mcs doctor` used to list the id on its "Packs (…)" line and then run no checks
+    /// for it in silence, because the advisory was gated on `--pack`.
+    @Test("Bare doctor warns about a configured pack that produced no checks")
+    func bareDoctorWarnsAboutPackWithNoChecks() throws {
+        let (home, project) = try makeSandboxProject(label: "doctor-unloadable")
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let registry = TechPackRegistry(packs: [MockTechPack(identifier: "test-pack", displayName: "Test Pack")])
+
+        var baselineState = try ProjectState(projectRoot: project)
+        baselineState.recordPack("test-pack")
+        try baselineState.save()
+
+        var baselineRunner = makeRunner(home: home, projectRoot: project, registry: registry)
+        let baseline = try baselineRunner.run()
+
+        // Now also tracking a pack the registry could not produce.
+        var state = try ProjectState(projectRoot: project)
+        state.recordPack("ghost-pack")
+        try state.save()
+
+        var ghostRunner = makeRunner(home: home, projectRoot: project, registry: registry)
+        let withGhost = try ghostRunner.run()
+
+        #expect(withGhost.warnings == baseline.warnings + 1)
+    }
 }

--- a/Tests/MCSTests/ExternalPackLoaderTests.swift
+++ b/Tests/MCSTests/ExternalPackLoaderTests.swift
@@ -312,6 +312,78 @@ struct ExternalPackLoaderTests {
         #expect(adapters[0].identifier == "my-pack")
     }
 
+    // MARK: - Trust verification at load
+
+    /// Write a pack checkout declaring one hook file, and register it with `hashes` — called with
+    /// the hook's real hash so a case can record it, corrupt it, or leave it out.
+    private func seedHookPack(
+        env: Environment,
+        hashes: (String) -> [String: String]
+    ) throws -> ExternalPackLoader {
+        let packDir = env.packsDirectory.appendingPathComponent("hook-pack")
+        let hookFile = packDir.appendingPathComponent("hooks/gate.sh")
+        try FileManager.default.createDirectory(
+            at: hookFile.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try "#!/bin/bash\necho gate".write(to: hookFile, atomically: true, encoding: .utf8)
+        try """
+        schemaVersion: 1
+        identifier: hook-pack
+        displayName: Hook Pack
+        description: A pack with one hook
+        components:
+          - id: gate
+            displayName: Gate Hook
+            description: A hook
+            hookEvent: PreToolUse
+            hook:
+              source: hooks/gate.sh
+              destination: gate.sh
+        """.write(
+            to: packDir.appendingPathComponent("techpack.yaml"), atomically: true, encoding: .utf8
+        )
+
+        let hookHash = try FileHasher.sha256(of: hookFile)
+        let registry = PackRegistryFile(path: env.packsRegistry)
+        var data = PackRegistryFile.RegistryData()
+        var entry = makeRegistryEntry(identifier: "hook-pack")
+        entry.trustedScriptHashes = hashes(hookHash)
+        registry.register(entry, in: &data)
+        try registry.save(data)
+        return ExternalPackLoader(environment: env, registry: registry)
+    }
+
+    @Test("loadAll loads a pack whose trust map still names a file it no longer ships")
+    func loadAllIgnoresOrphanedTrustedHash() throws {
+        let (tmpDir, env) = try setupTestEnv()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // A pack renamed its scripts, so the map carries hashes for paths that no longer exist
+        // alongside valid ones.
+        let loader = try seedHookPack(env: env) { hookHash in
+            ["hooks/gate.sh": hookHash, "hooks/legacy.sh": "abc123"]
+        }
+
+        let adapters = loader.loadAll(output: CLIOutput(colorsEnabled: false))
+
+        #expect(adapters.count == 1)
+        #expect(adapters[0].identifier == "hook-pack")
+    }
+
+    @Test("loadAll refuses a pack whose referenced hook was never trusted")
+    func loadAllRefusesNeverTrustedHook() throws {
+        let (tmpDir, env) = try setupTestEnv()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Nothing recorded for a script the pack will run: no stored key to iterate, so the
+        // key-driven check never looked at it.
+        let loader = try seedHookPack(env: env) { _ in [:] }
+
+        let adapters = loader.loadAll(output: CLIOutput(colorsEnabled: false))
+
+        #expect(adapters.isEmpty)
+    }
+
     @Test("loadAll skips packs with missing checkout")
     func loadAllSkipsMissing() throws {
         let (tmpDir, env) = try setupTestEnv()

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -2328,6 +2328,79 @@ struct UpdateReapplyLifecycleTests {
         #expect(try bed.globalState().configuredPacks.contains("shared-pack"))
         #expect(FileManager.default.fileExists(atPath: projectHook.path))
     }
+
+    @Test("A skipped pack makes the whole scope skip re-apply instead of unconfiguring it")
+    func skippedPackIsNotUnconfigured() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let sourceA = try bed.makeHookSource(name: "a.sh")
+        let sourceB = try bed.makeHookSource(name: "b.sh")
+        // Registered hooks, so the settings-recomposition assertion below is not vacuous:
+        // without a `hookRegistration` no settings entry is ever written to compare against.
+        let packA = MockTechPack(
+            identifier: "pack-a",
+            displayName: "Pack A",
+            components: [bed.hookComponent(
+                pack: "pack-a", id: "a", source: sourceA, destination: "a.sh",
+                hookRegistration: HookRegistration(event: .preToolUse)
+            )]
+        )
+        let packB = MockTechPack(
+            identifier: "pack-b",
+            displayName: "Pack B",
+            components: [bed.hookComponent(
+                pack: "pack-b", id: "b", source: sourceB, destination: "b.sh",
+                hookRegistration: HookRegistration(event: .preToolUse)
+            )]
+        )
+        let registry = TechPackRegistry(packs: [packA, packB])
+
+        // Two packs in one scope: with a single pack the "no packs to refresh" guard masks the bug.
+        try bed.makeConfigurator(registry: registry)
+            .configure(packs: [packA, packB], confirmRemovals: false)
+
+        let hookA = bed.project.appendingPathComponent(".claude/hooks/pack-a/a.sh")
+        let hookB = bed.project.appendingPathComponent(".claude/hooks/pack-b/b.sh")
+        #expect(FileManager.default.fileExists(atPath: hookA.path))
+        #expect(FileManager.default.fileExists(atPath: hookB.path))
+
+        // Deleting A's hook distinguishes "scope was skipped" from "scope converged": a re-apply
+        // that ran would restore it, since `copyPackFile` is convergent.
+        try FileManager.default.removeItem(at: hookA)
+
+        let runs = try UpdateScopeResolver(environment: bed.env, output: CLIOutput(colorsEnabled: false))
+            .resolve(filter: .projectOnly, projectRoot: bed.project)
+        #expect(runs.count == 1)
+
+        for run in runs {
+            try UpdateCommand.reapplyScope(
+                run,
+                skippedPackIDs: ["pack-b"],
+                registry: registry,
+                dryRun: false,
+                env: bed.env,
+                shell: ShellRunner(environment: bed.env),
+                output: CLIOutput(colorsEnabled: false),
+                claudeCLI: bed.mockCLI
+            )
+        }
+
+        // Subtracting B from the desired state used to unconfigure it with no prompt, so a
+        // declined trust prompt or a network failure uninstalled the pack (#382).
+        #expect(try bed.projectState().configuredPacks.contains("pack-b"))
+        #expect(FileManager.default.fileExists(atPath: hookB.path))
+
+        // `configure` recomposes hooks from the pack list it is handed, so excluding B would
+        // strip the entry that invokes the hook it kept.
+        let settings = try Settings.load(from: bed.settingsLocalPath)
+        let hookCommands = (settings.hooks ?? [:]).values
+            .flatMap(\.self).flatMap { $0.hooks ?? [] }.compactMap(\.command)
+        #expect(hookCommands.contains(bed.projectHookCommand("pack-b/b.sh")))
+
+        // The accepted cost of skipping the scope: A is not refreshed this run.
+        #expect(!FileManager.default.fileExists(atPath: hookA.path))
+    }
 }
 
 // MARK: - Scenario: Hook Interpreters

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -2319,8 +2319,7 @@ struct UpdateReapplyLifecycleTests {
                 output: CLIOutput(colorsEnabled: false),
                 claudeCLI: bed.mockCLI
             )
-            // Nothing is skipped or unloadable here, so every scope must actually converge —
-            // a blocked scope would satisfy the state assertions below without doing anything.
+            // A blocked scope would satisfy the assertions below without doing anything.
             #expect(!blocked)
         }
 
@@ -2436,10 +2435,8 @@ struct UpdateReapplyLifecycleTests {
         let hookB = bed.project.appendingPathComponent(".claude/hooks/pack-b/b.sh")
         #expect(FileManager.default.fileExists(atPath: hookB.path))
 
-        // B is still recorded in project state but has no registry entry at all — a half-finished
-        // `mcs pack add` on a fresh checkout, say. It never reaches `skippedPackIDs` (the update
-        // phase only iterates registry entries) and `unloadableConfiguredPacks` excludes it, so
-        // resolving the pack list used to drop it and delete its artifacts.
+        // B is in state with no registry entry, so it reaches neither `skippedPackIDs` (the
+        // update phase only iterates registry entries) nor `unloadableConfiguredPacks`.
         let registryWithoutB = TechPackRegistry(packs: [packA], registeredPackIDs: ["pack-a"])
 
         let runs = try UpdateScopeResolver(environment: bed.env, output: CLIOutput(colorsEnabled: false))

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -2309,7 +2309,7 @@ struct UpdateReapplyLifecycleTests {
         #expect(runs.count == (filter == .all ? 2 : 1))
 
         for run in runs {
-            try UpdateCommand.reapplyScope(
+            let blocked = try UpdateCommand.reapplyScope(
                 run,
                 skippedPackIDs: [],
                 registry: registry,
@@ -2319,6 +2319,9 @@ struct UpdateReapplyLifecycleTests {
                 output: CLIOutput(colorsEnabled: false),
                 claudeCLI: bed.mockCLI
             )
+            // Nothing is skipped or unloadable here, so every scope must actually converge —
+            // a blocked scope would satisfy the state assertions below without doing anything.
+            #expect(!blocked)
         }
 
         // The regression guard: an identity-based filter, or a list sourced from anywhere but
@@ -2374,7 +2377,7 @@ struct UpdateReapplyLifecycleTests {
         #expect(runs.count == 1)
 
         for run in runs {
-            try UpdateCommand.reapplyScope(
+            let blocked = try UpdateCommand.reapplyScope(
                 run,
                 skippedPackIDs: ["pack-b"],
                 registry: registry,
@@ -2384,6 +2387,7 @@ struct UpdateReapplyLifecycleTests {
                 output: CLIOutput(colorsEnabled: false),
                 claudeCLI: bed.mockCLI
             )
+            #expect(blocked)
         }
 
         // Subtracting B from the desired state used to unconfigure it with no prompt, so a
@@ -2400,6 +2404,69 @@ struct UpdateReapplyLifecycleTests {
 
         // The accepted cost of skipping the scope: A is not refreshed this run.
         #expect(!FileManager.default.fileExists(atPath: hookA.path))
+    }
+
+    @Test("A configured pack missing from the registry blocks the scope instead of being removed")
+    func unresolvedPackIsNotUnconfigured() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let sourceA = try bed.makeHookSource(name: "a.sh")
+        let sourceB = try bed.makeHookSource(name: "b.sh")
+        let packA = MockTechPack(
+            identifier: "pack-a",
+            displayName: "Pack A",
+            components: [bed.hookComponent(
+                pack: "pack-a", id: "a", source: sourceA, destination: "a.sh",
+                hookRegistration: HookRegistration(event: .preToolUse)
+            )]
+        )
+        let packB = MockTechPack(
+            identifier: "pack-b",
+            displayName: "Pack B",
+            components: [bed.hookComponent(
+                pack: "pack-b", id: "b", source: sourceB, destination: "b.sh",
+                hookRegistration: HookRegistration(event: .preToolUse)
+            )]
+        )
+
+        try bed.makeConfigurator(registry: TechPackRegistry(packs: [packA, packB]))
+            .configure(packs: [packA, packB], confirmRemovals: false)
+
+        let hookB = bed.project.appendingPathComponent(".claude/hooks/pack-b/b.sh")
+        #expect(FileManager.default.fileExists(atPath: hookB.path))
+
+        // B is still recorded in project state but has no registry entry at all — a half-finished
+        // `mcs pack add` on a fresh checkout, say. It never reaches `skippedPackIDs` (the update
+        // phase only iterates registry entries) and `unloadableConfiguredPacks` excludes it, so
+        // resolving the pack list used to drop it and delete its artifacts.
+        let registryWithoutB = TechPackRegistry(packs: [packA], registeredPackIDs: ["pack-a"])
+
+        let runs = try UpdateScopeResolver(environment: bed.env, output: CLIOutput(colorsEnabled: false))
+            .resolve(filter: .projectOnly, projectRoot: bed.project)
+        #expect(runs.count == 1)
+
+        for run in runs {
+            let blocked = try UpdateCommand.reapplyScope(
+                run,
+                skippedPackIDs: [],
+                registry: registryWithoutB,
+                dryRun: false,
+                env: bed.env,
+                shell: ShellRunner(environment: bed.env),
+                output: CLIOutput(colorsEnabled: false),
+                claudeCLI: bed.mockCLI
+            )
+            #expect(blocked)
+        }
+
+        #expect(try bed.projectState().configuredPacks.contains("pack-b"))
+        #expect(FileManager.default.fileExists(atPath: hookB.path))
+
+        let settings = try Settings.load(from: bed.settingsLocalPath)
+        let hookCommands = (settings.hooks ?? [:]).values
+            .flatMap(\.self).flatMap { $0.hooks ?? [] }.compactMap(\.command)
+        #expect(hookCommands.contains(bed.projectHookCommand("pack-b/b.sh")))
     }
 }
 

--- a/Tests/MCSTests/PackTrustManagerTests.swift
+++ b/Tests/MCSTests/PackTrustManagerTests.swift
@@ -557,12 +557,13 @@ struct PackTrustManagerTests {
         #expect(modified == ["scripts/doctor.sh": .mismatched])
     }
 
-    @Test("verifyTrust leaves a genuine inline doctor command exempt")
-    func verifyTrustExemptsInlineDoctorCommand() throws {
+    @Test("verifyTrust does not report a doctor script path that was never trusted as a file")
+    func verifyTrustIgnoresNeverTrustedDoctorPath() throws {
         let tmpDir = try makeTmpDir()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        // A real shell command, not a path: it never had a file, so it stays exempt.
+        // A declared path with no file is a broken pack, which doctor reports at run time. It was
+        // never trusted as a file, so it must not be reported here as a deleted script.
         let manifest = try loadManifest(yaml: """
         schemaVersion: 1
         identifier: test
@@ -571,7 +572,7 @@ struct PackTrustManagerTests {
         supplementaryDoctorChecks:
           - type: shellScript
             name: Check Env
-            command: swift build
+            command: scripts/absent.sh
         """, in: tmpDir)
 
         let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))

--- a/Tests/MCSTests/PackTrustManagerTests.swift
+++ b/Tests/MCSTests/PackTrustManagerTests.swift
@@ -547,8 +547,7 @@ struct PackTrustManagerTests {
         )
         #expect(trusted["scripts/doctor.sh"] != nil)
 
-        // Deleting the file makes `analyzeScripts` reclassify the declared path as an inline
-        // command, which would otherwise slip past the inline exemption unverified.
+        // Deleting the file reclassifies the declared path as an inline command.
         try FileManager.default.removeItem(at: scriptFile)
 
         let modified = try manager.verifyTrust(
@@ -563,8 +562,7 @@ struct PackTrustManagerTests {
         let tmpDir = try makeTmpDir()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        // `command` here is a real shell command, not a path — it has no file and never had one,
-        // so it must stay exempt rather than being reported as a deleted script.
+        // A real shell command, not a path: it never had a file, so it stays exempt.
         let manifest = try loadManifest(yaml: """
         schemaVersion: 1
         identifier: test

--- a/Tests/MCSTests/PackTrustManagerTests.swift
+++ b/Tests/MCSTests/PackTrustManagerTests.swift
@@ -514,6 +514,81 @@ struct PackTrustManagerTests {
         #expect(modified == ["hooks/gate.sh": .neverTrusted])
     }
 
+    /// A pack whose only trustable content is one doctor `shellScript` check.
+    private func doctorScriptPackYAML() -> String {
+        """
+        schemaVersion: 1
+        identifier: test
+        displayName: Test Pack
+        description: A test pack
+        supplementaryDoctorChecks:
+          - type: shellScript
+            name: Check Env
+            command: scripts/doctor.sh
+        """
+    }
+
+    @Test("verifyTrust flags a trusted doctor script that was deleted")
+    func verifyTrustFlagsDeletedDoctorScript() throws {
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let scriptFile = tmpDir.appendingPathComponent("scripts/doctor.sh")
+        try FileManager.default.createDirectory(
+            at: scriptFile.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try writeFile("#!/bin/bash\necho ok", at: scriptFile)
+
+        let manifest = try loadManifest(yaml: doctorScriptPackYAML(), in: tmpDir)
+        let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
+        let trusted = try manager.computeScriptHashes(
+            items: manager.analyzeScripts(manifest: manifest, packPath: tmpDir),
+            packPath: tmpDir
+        )
+        #expect(trusted["scripts/doctor.sh"] != nil)
+
+        // Deleting the file makes `analyzeScripts` reclassify the declared path as an inline
+        // command, which would otherwise slip past the inline exemption unverified.
+        try FileManager.default.removeItem(at: scriptFile)
+
+        let modified = try manager.verifyTrust(
+            trustedHashes: trusted, packPath: tmpDir, manifest: manifest
+        )
+
+        #expect(modified == ["scripts/doctor.sh": .mismatched])
+    }
+
+    @Test("verifyTrust leaves a genuine inline doctor command exempt")
+    func verifyTrustExemptsInlineDoctorCommand() throws {
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // `command` here is a real shell command, not a path — it has no file and never had one,
+        // so it must stay exempt rather than being reported as a deleted script.
+        let manifest = try loadManifest(yaml: """
+        schemaVersion: 1
+        identifier: test
+        displayName: Test Pack
+        description: A test pack
+        supplementaryDoctorChecks:
+          - type: shellScript
+            name: Check Env
+            command: swift build
+        """, in: tmpDir)
+
+        let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
+        let trusted = try manager.computeScriptHashes(
+            items: manager.analyzeScripts(manifest: manifest, packPath: tmpDir),
+            packPath: tmpDir
+        )
+
+        let modified = try manager.verifyTrust(
+            trustedHashes: trusted, packPath: tmpDir, manifest: manifest
+        )
+
+        #expect(modified.isEmpty)
+    }
+
     @Test("verifyTrust skips inline synthetic keys")
     func verifyTrustSkipsInlineKeys() throws {
         let tmpDir = try makeTmpDir()

--- a/Tests/MCSTests/PackTrustManagerTests.swift
+++ b/Tests/MCSTests/PackTrustManagerTests.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 @testable import mcs
 import Testing
@@ -108,10 +107,10 @@ struct PackTrustManagerTests {
 
         // Trusted before interpreter items existed: only the script file has a hash.
         let legacyHashes = try ["hooks/gate.sh": sha256(of: tmpDir.appendingPathComponent("hooks/gate.sh"))]
-        let changed = try manager.detectNewScripts(
-            currentHashes: legacyHashes,
-            updatedPackPath: tmpDir,
-            manifest: manifest
+        let changed = try manager.newOrChanged(
+            in: manager.analyzeScripts(manifest: manifest, packPath: tmpDir),
+            against: legacyHashes,
+            packPath: tmpDir
         )
         #expect(changed.isEmpty)
         #expect(items.contains { $0.type == .hookInterpreter })
@@ -139,10 +138,10 @@ struct PackTrustManagerTests {
         // The update drops the interpreter, so the same bytes now run under bash. A polyglot
         // script reviewed as JS would begin executing its shell branch unreviewed.
         let after = try loadManifest(yaml: hookPackYAML(interpreterLine: nil), in: tmpDir)
-        let changed = try manager.detectNewScripts(
-            currentHashes: trusted,
-            updatedPackPath: tmpDir,
-            manifest: after
+        let changed = try manager.newOrChanged(
+            in: manager.analyzeScripts(manifest: after, packPath: tmpDir),
+            against: trusted,
+            packPath: tmpDir
         )
         #expect(changed.contains { $0.type == .hookInterpreter })
     }
@@ -212,10 +211,10 @@ struct PackTrustManagerTests {
 
         // The update leaves the script byte-identical and swaps only the interpreter.
         let after = try loadManifest(yaml: hookPackYAML(interpreterLine: "sh -c"), in: tmpDir)
-        let changed = try manager.detectNewScripts(
-            currentHashes: trusted,
-            updatedPackPath: tmpDir,
-            manifest: after
+        let changed = try manager.newOrChanged(
+            in: manager.analyzeScripts(manifest: after, packPath: tmpDir),
+            against: trusted,
+            packPath: tmpDir
         )
 
         // Without the interpreter in the trust surface this returns empty: same file hash, no
@@ -237,10 +236,10 @@ struct PackTrustManagerTests {
             items: manager.analyzeScripts(manifest: manifest, packPath: tmpDir),
             packPath: tmpDir
         )
-        let changed = try manager.detectNewScripts(
-            currentHashes: trusted,
-            updatedPackPath: tmpDir,
-            manifest: manifest
+        let changed = try manager.newOrChanged(
+            in: manager.analyzeScripts(manifest: manifest, packPath: tmpDir),
+            against: trusted,
+            packPath: tmpDir
         )
         #expect(changed.isEmpty)
     }
@@ -413,19 +412,31 @@ struct PackTrustManagerTests {
 
     // MARK: - verifyTrust
 
+    /// A pack declaring one hook at `hooks/gate.sh`, with that file written to disk.
+    /// Returns the manifest and the hook's current hash.
+    private func hookPack(in tmpDir: URL) throws -> (manifest: ExternalPackManifest, hash: String) {
+        let manifest = try loadManifest(yaml: hookPackYAML(interpreterLine: nil), in: tmpDir)
+        let scriptFile = tmpDir.appendingPathComponent("hooks/gate.sh")
+        try FileManager.default.createDirectory(
+            at: scriptFile.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try writeFile("#!/bin/bash\necho ok", at: scriptFile)
+        let hash = try sha256(of: scriptFile)
+        return (manifest, hash)
+    }
+
     @Test("verifyTrust returns empty for matching hashes")
     func verifyTrustMatchingHashes() throws {
         let tmpDir = try makeTmpDir()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        let scriptFile = tmpDir.appendingPathComponent("script.sh")
-        try writeFile("#!/bin/bash\necho ok", at: scriptFile)
-        let hash = try sha256(of: scriptFile)
+        let pack = try hookPack(in: tmpDir)
 
         let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
-        let modified = manager.verifyTrust(
-            trustedHashes: ["script.sh": hash],
-            packPath: tmpDir
+        let modified = try manager.verifyTrust(
+            trustedHashes: ["hooks/gate.sh": pack.hash],
+            packPath: tmpDir,
+            manifest: pack.manifest
         )
 
         #expect(modified.isEmpty)
@@ -436,31 +447,71 @@ struct PackTrustManagerTests {
         let tmpDir = try makeTmpDir()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        let scriptFile = tmpDir.appendingPathComponent("script.sh")
-        try writeFile("#!/bin/bash\necho ok", at: scriptFile)
+        let pack = try hookPack(in: tmpDir)
 
-        // Use a different hash than what's on disk
         let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
-        let modified = manager.verifyTrust(
-            trustedHashes: ["script.sh": "0000000000000000000000000000000000000000000000000000000000000000"],
-            packPath: tmpDir
+        let modified = try manager.verifyTrust(
+            trustedHashes: ["hooks/gate.sh": "0000000000000000000000000000000000000000000000000000000000000000"],
+            packPath: tmpDir,
+            manifest: pack.manifest
         )
 
-        #expect(modified == ["script.sh"])
+        #expect(modified == ["hooks/gate.sh": .mismatched])
     }
 
-    @Test("verifyTrust flags missing files")
+    @Test("verifyTrust flags a referenced file that is missing from disk")
     func verifyTrustMissingFile() throws {
         let tmpDir = try makeTmpDir()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
+        // Manifest declares hooks/gate.sh, but the file is never written.
+        let manifest = try loadManifest(yaml: hookPackYAML(interpreterLine: nil), in: tmpDir)
+
         let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
-        let modified = manager.verifyTrust(
-            trustedHashes: ["nonexistent.sh": "abc123"],
-            packPath: tmpDir
+        let modified = try manager.verifyTrust(
+            trustedHashes: ["hooks/gate.sh": "abc123"],
+            packPath: tmpDir,
+            manifest: manifest
         )
 
-        #expect(modified == ["nonexistent.sh"])
+        // A referenced file that is gone reads as mismatched, not as an unreadable-file error.
+        #expect(modified == ["hooks/gate.sh": .mismatched])
+    }
+
+    @Test("verifyTrust ignores a stored key the manifest no longer references")
+    func verifyTrustIgnoresOrphanedKey() throws {
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let pack = try hookPack(in: tmpDir)
+
+        // The orphaned key is what bricked a pack that renamed all of its scripts.
+        let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
+        let modified = try manager.verifyTrust(
+            trustedHashes: ["hooks/gate.sh": pack.hash, "hooks/legacy.sh": "abc123"],
+            packPath: tmpDir,
+            manifest: pack.manifest
+        )
+
+        #expect(modified.isEmpty)
+    }
+
+    @Test("verifyTrust flags a referenced script that was never trusted")
+    func verifyTrustFlagsNeverTrustedScript() throws {
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let pack = try hookPack(in: tmpDir)
+
+        // On disk with no hash recorded — unchecked while verification walked the stored keys.
+        let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
+        let modified = try manager.verifyTrust(
+            trustedHashes: [:],
+            packPath: tmpDir,
+            manifest: pack.manifest
+        )
+
+        #expect(modified == ["hooks/gate.sh": .neverTrusted])
     }
 
     @Test("verifyTrust skips inline synthetic keys")
@@ -468,13 +519,29 @@ struct PackTrustManagerTests {
         let tmpDir = try makeTmpDir()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
+        // Inline items stay out of the load-time gate even with no hash recorded.
+        let manifest = try loadManifest(yaml: """
+        schemaVersion: 1
+        identifier: test
+        displayName: Test Pack
+        description: A test pack
+        components:
+          - id: test.setup
+            displayName: Setup
+            description: Runs a command
+            type: configuration
+            installAction:
+              type: shellCommand
+              command: "echo hello"
+        """, in: tmpDir)
+
         let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
-        let modified = manager.verifyTrust(
+        let modified = try manager.verifyTrust(
             trustedHashes: ["inline:abc123def456": "somehash"],
-            packPath: tmpDir
+            packPath: tmpDir,
+            manifest: manifest
         )
 
-        // Inline keys should be skipped (no corresponding file on disk)
         #expect(modified.isEmpty)
     }
 
@@ -539,10 +606,10 @@ struct PackTrustManagerTests {
         let manifest = try loadManifest(yaml: yaml, in: tmpDir)
         let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
 
-        let newItems = try manager.detectNewScripts(
-            currentHashes: ["scripts/configure.sh": hash],
-            updatedPackPath: tmpDir,
-            manifest: manifest
+        let newItems = try manager.newOrChanged(
+            in: manager.analyzeScripts(manifest: manifest, packPath: tmpDir),
+            against: ["scripts/configure.sh": hash],
+            packPath: tmpDir
         )
 
         #expect(newItems.isEmpty)
@@ -570,10 +637,10 @@ struct PackTrustManagerTests {
         let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
 
         // Empty trusted hashes means everything is "new"
-        let newItems = try manager.detectNewScripts(
-            currentHashes: [:],
-            updatedPackPath: tmpDir,
-            manifest: manifest
+        let newItems = try manager.newOrChanged(
+            in: manager.analyzeScripts(manifest: manifest, packPath: tmpDir),
+            against: [:],
+            packPath: tmpDir
         )
 
         #expect(newItems.count == 1)
@@ -602,10 +669,10 @@ struct PackTrustManagerTests {
         let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
 
         // Hash doesn't match the file on disk
-        let newItems = try manager.detectNewScripts(
-            currentHashes: ["scripts/configure.sh": "oldhash000000"],
-            updatedPackPath: tmpDir,
-            manifest: manifest
+        let newItems = try manager.newOrChanged(
+            in: manager.analyzeScripts(manifest: manifest, packPath: tmpDir),
+            against: ["scripts/configure.sh": "oldhash000000"],
+            packPath: tmpDir
         )
 
         #expect(newItems.count == 1)

--- a/Tests/MCSTests/PackUpdaterTests.swift
+++ b/Tests/MCSTests/PackUpdaterTests.swift
@@ -200,6 +200,106 @@ struct PackUpdaterTests {
         }
     }
 
+    /// A manifest whose only trustable content is `configureProject.script`, plus that script —
+    /// one file-backed item and no inline ones, so the trust map has exactly one expected key.
+    private func pushConfigureScript(fixture: Fixture, body: String) throws {
+        try pushFiles(fixture: fixture, files: [
+            "scripts/configure.sh": body,
+            "techpack.yaml": """
+            schemaVersion: 1
+            identifier: test-pack
+            displayName: Test Pack
+            description: A test pack
+            configureProject:
+              script: scripts/configure.sh
+            """,
+        ])
+    }
+
+    @Test("update drops a trusted hash for a script the manifest no longer references")
+    func updatePrunesOrphanedHash() throws {
+        let fix = try makeFixture()
+        defer { fix.cleanup() }
+
+        // Nothing new is detected and no prompt fires, yet the merge-only update kept the key
+        // and `verifyTrust` then refused the pack over a file it no longer ships.
+        let entry = makeEntry(
+            commitSHA: fix.initialSHA,
+            trustedScriptHashes: ["hooks/legacy.sh": "abc123"]
+        )
+        let packPath = fix.packsDir.appendingPathComponent("test-pack")
+        _ = try pushNewCommit(fixture: fix)
+
+        let result = fix.updater.updateGitPack(
+            entry: entry, packPath: packPath, registry: fix.registry
+        )
+
+        guard case let .updated(updatedEntry, _) = result else {
+            Issue.record("Expected .updated, got \(result)")
+            return
+        }
+        #expect(updatedEntry.trustedScriptHashes.isEmpty)
+    }
+
+    @Test("prompts for re-trust at an unchanged commit when the trust map does not cover disk")
+    func staleTrustAtSameCommitPrompts() throws {
+        let fix = try makeFixture()
+        defer { fix.cleanup() }
+
+        // Registry entry sits at the same commit as the checkout with nothing recorded for the
+        // script — the state a declined trust prompt plus a baseline advance produces.
+        try pushConfigureScript(fixture: fix, body: "#!/bin/bash\necho configure")
+        let packPath = fix.packsDir.appendingPathComponent("test-pack")
+        guard let fetched = try fix.fetcher.update(packPath: packPath, ref: nil) else {
+            Issue.record("Expected the fetch to advance the checkout")
+            return
+        }
+
+        let entry = makeEntry(commitSHA: fetched.commitSHA)
+
+        let result = fix.updater.updateGitPack(
+            entry: entry, packPath: packPath, registry: fix.registry
+        )
+
+        // Reaching the prompt is the assertion: it declines non-interactively, where it used to
+        // short-circuit to .alreadyUpToDate and leave the pack unrecoverable.
+        guard case .trustDeclined = result else {
+            Issue.record("Expected .trustDeclined, got \(result)")
+            return
+        }
+    }
+
+    @Test("stays alreadyUpToDate at an unchanged commit when the trust map covers disk")
+    func currentTrustAtSameCommitIsUpToDate() throws {
+        let fix = try makeFixture()
+        defer { fix.cleanup() }
+
+        try pushConfigureScript(fixture: fix, body: "#!/bin/bash\necho configure")
+        let packPath = fix.packsDir.appendingPathComponent("test-pack")
+        guard let fetched = try fix.fetcher.update(packPath: packPath, ref: nil) else {
+            Issue.record("Expected the fetch to advance the checkout")
+            return
+        }
+
+        let scriptHash = try FileHasher.sha256(
+            of: packPath.appendingPathComponent("scripts/configure.sh")
+        )
+        let entry = makeEntry(
+            commitSHA: fetched.commitSHA,
+            trustedScriptHashes: ["scripts/configure.sh": scriptHash]
+        )
+
+        let result = fix.updater.updateGitPack(
+            entry: entry, packPath: packPath, registry: fix.registry
+        )
+
+        // A fully-trusted pack must not be re-prompted on every update run.
+        guard case .alreadyUpToDate = result else {
+            Issue.record("Expected .alreadyUpToDate, got \(result)")
+            return
+        }
+    }
+
     @Test("returns updated when remote has a new commit (no new scripts)")
     func normalUpdateNoScripts() throws {
         let fix = try makeFixture()

--- a/Tests/MCSTests/SyncCommandTests.swift
+++ b/Tests/MCSTests/SyncCommandTests.swift
@@ -452,10 +452,8 @@ struct SyncCommandGuardTests {
 
 // MARK: - Unloadable-pack guard
 
-/// The sync guard's decision. `SyncCommand.perform()` builds its own `Environment()`, so the
-/// surrounding command cannot be driven from a sandboxed bed; the destructive half of this
-/// behaviour — what convergence does to a pack left out of the desired state — is covered
-/// end-to-end by `UpdateReapplyLifecycleTests`.
+/// The guard's decision only — the command around it builds its own `Environment()`. What
+/// convergence destroys when a pack is left out is covered by `UpdateReapplyLifecycleTests`.
 struct SyncUnloadablePackGuardTests {
     private func silentOutput() -> CLIOutput {
         CLIOutput(colorsEnabled: false)
@@ -475,8 +473,7 @@ struct SyncUnloadablePackGuardTests {
 
     @Test("A configured pack with no registry entry does not block the scope")
     func doesNotBlockOnUnregisteredPack() {
-        // Absent rather than broken: sync may legitimately be deselecting it, and retaining it
-        // would be unremovable since `mcs pack remove` refuses an unknown identifier.
+        // Absent rather than broken: sync may legitimately be deselecting it.
         let registry = TechPackRegistry(
             packs: [MockTechPack(identifier: "pack-a", displayName: "Pack A")],
             registeredPackIDs: ["pack-a"]

--- a/Tests/MCSTests/SyncCommandTests.swift
+++ b/Tests/MCSTests/SyncCommandTests.swift
@@ -449,3 +449,60 @@ struct SyncCommandGuardTests {
         }
     }
 }
+
+// MARK: - Unloadable-pack guard
+
+/// The sync guard's decision. `SyncCommand.perform()` builds its own `Environment()`, so the
+/// surrounding command cannot be driven from a sandboxed bed; the destructive half of this
+/// behaviour — what convergence does to a pack left out of the desired state — is covered
+/// end-to-end by `UpdateReapplyLifecycleTests`.
+struct SyncUnloadablePackGuardTests {
+    private func silentOutput() -> CLIOutput {
+        CLIOutput(colorsEnabled: false)
+    }
+
+    @Test("A registered pack that failed to load blocks the scope")
+    func blocksOnUnloadablePack() {
+        let registry = TechPackRegistry(
+            packs: [MockTechPack(identifier: "pack-a", displayName: "Pack A")],
+            registeredPackIDs: ["pack-a", "pack-b"]
+        )
+
+        #expect(SyncCommand.scopeIsBlockedByUnloadablePack(
+            configured: ["pack-a", "pack-b"], registry: registry, output: silentOutput()
+        ))
+    }
+
+    @Test("A configured pack with no registry entry does not block the scope")
+    func doesNotBlockOnUnregisteredPack() {
+        // Absent rather than broken: sync may legitimately be deselecting it, and retaining it
+        // would be unremovable since `mcs pack remove` refuses an unknown identifier.
+        let registry = TechPackRegistry(
+            packs: [MockTechPack(identifier: "pack-a", displayName: "Pack A")],
+            registeredPackIDs: ["pack-a"]
+        )
+
+        #expect(!SyncCommand.scopeIsBlockedByUnloadablePack(
+            configured: ["pack-a", "ghost-pack"], registry: registry, output: silentOutput()
+        ))
+    }
+
+    @Test("Everything loading cleanly does not block the scope")
+    func doesNotBlockWhenAllLoaded() {
+        let registry = TechPackRegistry(
+            packs: [MockTechPack(identifier: "pack-a", displayName: "Pack A")],
+            registeredPackIDs: ["pack-a"]
+        )
+
+        #expect(!SyncCommand.scopeIsBlockedByUnloadablePack(
+            configured: ["pack-a"], registry: registry, output: silentOutput()
+        ))
+    }
+
+    @Test("An empty configured set never blocks")
+    func doesNotBlockOnEmptyScope() {
+        #expect(!SyncCommand.scopeIsBlockedByUnloadablePack(
+            configured: [], registry: TechPackRegistry(), output: silentOutput()
+        ))
+    }
+}

--- a/Tests/MCSTests/TechPackRegistryTests.swift
+++ b/Tests/MCSTests/TechPackRegistryTests.swift
@@ -111,6 +111,42 @@ struct TechPackRegistryTests {
         #expect(!checks.isEmpty)
         #expect(checks.first?.name == "test-check")
     }
+
+    // MARK: - unloadableConfiguredPacks
+
+    @Test("A registered pack that did not load is reported as unloadable")
+    func unloadableReportsRegisteredButNotLoaded() {
+        // pack-b is in `registry.yaml` but produced no adapter — trust verification, an invalid
+        // manifest, or a missing checkout, all of which `loadAll` warned about and skipped.
+        let registry = TechPackRegistry(
+            packs: [FakeTechPack(identifier: "pack-a")],
+            registeredPackIDs: ["pack-a", "pack-b"]
+        )
+
+        #expect(registry.unloadableConfiguredPacks(configured: ["pack-a", "pack-b"]) == ["pack-b"])
+    }
+
+    @Test("A configured pack with no registry entry is not reported as unloadable")
+    func unloadableExcludesUnregisteredPack() {
+        // `ghost-pack` is in project state but not installed at all, so converging it away is the
+        // intended repair — and `mcs pack remove` could not clean it up if it were retained.
+        let registry = TechPackRegistry(
+            packs: [FakeTechPack(identifier: "pack-a")],
+            registeredPackIDs: ["pack-a"]
+        )
+
+        #expect(registry.unloadableConfiguredPacks(configured: ["pack-a", "ghost-pack"]).isEmpty)
+    }
+
+    @Test("Everything loading cleanly reports nothing")
+    func unloadableEmptyWhenAllLoaded() {
+        let registry = TechPackRegistry(
+            packs: [FakeTechPack(identifier: "pack-a")],
+            registeredPackIDs: ["pack-a"]
+        )
+
+        #expect(registry.unloadableConfiguredPacks(configured: ["pack-a"]).isEmpty)
+    }
 }
 
 // MARK: - Test Helper

--- a/Tests/MCSTests/UpdateCheckerTests.swift
+++ b/Tests/MCSTests/UpdateCheckerTests.swift
@@ -370,7 +370,8 @@ struct UpdateCheckerOrchestratorTests {
             .appendingPathComponent("pack-a").path
         #expect(mock.runCalls[0].arguments == ["fetch", "--depth", "1", "origin"])
         #expect(mock.runCalls[0].workingDirectory == expectedWorkDir)
-        #expect(mock.runCalls[1].arguments == ["diff", "--name-only", "HEAD", "origin/HEAD"])
+        // Diffed from the registry baseline, not HEAD — see `classifyUpstreamChange`.
+        #expect(mock.runCalls[1].arguments == ["diff", "--name-only", "old123", "origin/HEAD"])
         #expect(mock.runCalls[1].workingDirectory == expectedWorkDir)
     }
 
@@ -408,7 +409,7 @@ struct UpdateCheckerOrchestratorTests {
         _ = checker.classifyUpstreamChange(entry: makeEntry(ref: "v2.0"))
 
         #expect(mock.runCalls[0].arguments == ["fetch", "--depth", "1", "origin", "v2.0"])
-        #expect(mock.runCalls[1].arguments == ["diff", "--name-only", "HEAD", "FETCH_HEAD"])
+        #expect(mock.runCalls[1].arguments == ["diff", "--name-only", "old123", "FETCH_HEAD"])
     }
 
     @Test("Invalid entry.ref (argument injection) → .unknown(.fetchFailed); no git invocation")


### PR DESCRIPTION
## Summary

A pack whose update renamed its scripts stopped loading and could not be recovered. The trust map kept hashes for files the pack no longer shipped, verification read those absences as tampering, and the `mcs pack update` the error message recommends reported "already up to date" — because the equal-commit path never looked at trust state. Removing and re-adding the pack was the only way out.

## Changes

- Trust verification walks the pack's current manifest instead of the recorded hash map, so leftover keys for renamed or deleted scripts are ignored. A referenced script with no recorded hash — previously unverified at load — is now refused.
- An update rebuilds the hash map from what the pack currently declares rather than merging into the old one, so orphaned entries stop accumulating.
- `mcs pack update` re-checks trust when the commit has not moved, so its own recovery advice works.
- A pack that cannot be produced is no longer read as deselected. The scope's sync or re-apply is skipped with a warning instead of deleting that pack's artifacts. For `mcs update` that covers every way a pack can go missing from a run — fetch failure, declined trust, an invalid registry path, or an entry absent from the registry altogether (closes #382). `mcs doctor` now says when it ran no checks for a configured pack instead of listing the id in silence.
- A scope that was skipped no longer has its lockfile rewritten, which would otherwise record commits whose artifacts were never applied. Read-only drift reporting is unaffected.
- Update-check suppression compares the remote against the recorded commit rather than the checkout, so it cannot advance the recorded commit past scripts that were never trusted.

Scripts referenced only from a `shell:` string, and inline `shell:`/MCP commands, are still not verified at load — the latter is a compatibility window for trust maps written before inline hashing, noted in the code.

## Test plan

- [x] `swift test` passes locally
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

Manual verification (not yet run — each mutates real `~/.mcs` state, so it needs a throwaway pack):

1. Add a pack shipping a hook, push an upstream commit renaming that hook file, then `mcs pack update <pack>` and approve → expect the pack to keep loading on the next `mcs sync`. Before this change it failed trust verification and the update reported "already up to date" forever.
2. Leave a pack's recorded trust stale at its current commit, then `mcs pack update <pack>` → expect a trust prompt, not "already up to date".
3. Make a configured pack fail to load (corrupt one of its trusted scripts), then `mcs sync` → expect a warning and its artifacts left in place; `mcs doctor` → expect a warning naming the pack.

<details>
<summary>Checklist for engine changes</summary>

- [x] Integration tests updated for new features (`LifecycleIntegrationTests` or `DoctorRunnerIntegrationTests`)
- [ ] Docs updated if behavior changed (`CLAUDE.md`, `docs/`, `techpack.yaml` schema in `ExternalPackManifest.swift`)

</details>
