### PR TITLE
ISSUE-388: Verify brew packages the way sync already does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ mcs config set <key> <value>     # Set a configuration value (true/false)
 - `GitignoreManager.swift` — global gitignore management, core entry list
 - `ClaudeIntegration.swift` — `claude mcp add/remove` (with scope support), `claude plugin install/remove`
 - `ClaudePrerequisite.swift` — Claude Code CLI availability check with optional Homebrew auto-install
-- `Homebrew.swift` — brew detection, package install/uninstall
+- `Homebrew.swift` — brew detection, package install/uninstall, and `provides(_:)` — the one availability predicate shared by `ComponentExecutor` and `BrewPackageCheck` (PATH under `bareName(of:)`, falling back to `brew list`)
 - `FileHasher.swift` — SHA-256 file and directory hashing via CryptoKit (used by `PackTrustManager` and `ComponentExecutor`)
 - `FileLock.swift` — POSIX `flock()` process lock and `LockedCommand` protocol for mutually exclusive CLI commands
 - `Lockfile.swift` — `mcs.lock.yaml` model for pinning pack commits
@@ -109,11 +109,11 @@ mcs config set <key> <value>     # Set a configuration value (true/false)
 - `PromptExecutor.swift` — executes pack prompts (interactive value resolution during sync)
 - `ScriptRunner.swift` — sandboxed script execution for pack scripts
 - `ExternalDoctorCheck.swift` — factory for converting YAML doctor check definitions to `DoctorCheck` instances
-- `PackHeuristics.swift` — heuristic validation checks for `mcs pack validate` (empty pack, root source copy, missing files, unreferenced files, MCP dependency gaps, python module paths, `scope` declared on doctor check types that ignore it)
+- `PackHeuristics.swift` — heuristic validation checks for `mcs pack validate` (empty pack, root source copy, missing files, unreferenced files, MCP dependency gaps, python module paths, third-party brew taps, `scope` declared on doctor check types that ignore it)
 
 ### Doctor (`Sources/mcs/Doctor/`)
 - `DoctorRunner.swift` — 5-layer check orchestration with project-aware pack resolution
-- `CoreDoctorChecks.swift` — check structs (CommandCheck, MCPServerCheck, PluginCheck, HookCheck, GitignoreCheck, CommandFileCheck, FileExistsCheck, FileContentCheck, HookSettingsCheck, SettingsKeysCheck, SettingsDriftCheck, PackGitignoreCheck, ProjectIndexCheck)
+- `CoreDoctorChecks.swift` — check structs (BrewPackageCheck, MCPServerCheck, PluginCheck, HookCheck, GitignoreCheck, CommandFileCheck, FileExistsCheck, FileContentCheck, HookSettingsCheck, SettingsKeysCheck, SettingsDriftCheck, PackGitignoreCheck, ProjectIndexCheck)
 - `DerivedDoctorChecks.swift` — `deriveDoctorCheck()` extension on ComponentDefinition
 - `ProjectDoctorChecks.swift` — project-scoped checks (CLAUDE.local.md freshness, state file)
 - `ScopeDuplicationCheck.swift` — flags a pack configured in both the project and global scope, reporting only artifacts that genuinely exist twice; `--fix` removes the project copy via `Configurator.unconfigurePack`, gated on component subset, prompt-answer parity, and the recorded hash of every file it would delete

--- a/Sources/mcs/Core/Homebrew.swift
+++ b/Sources/mcs/Core/Homebrew.swift
@@ -22,6 +22,28 @@ struct Homebrew {
         return result.succeeded
     }
 
+    /// A declared name with any tap qualifier stripped: `owner/tap/formula` → `formula`.
+    ///
+    /// Purely lexical — deliberately not named for the command a formula provides, because no
+    /// such function can exist (see `provides`).
+    static func bareName(of package: String) -> String {
+        URL(fileURLWithPath: package).lastPathComponent
+    }
+
+    /// Whether `package` is available on this machine.
+    ///
+    /// A package name is not reliably a command name, so a PATH miss proves nothing and has to
+    /// be settled by asking brew: `ripgrep` installs `rg`, `node@22` and casks install nothing
+    /// matching at all. PATH stays the fast path because it costs no subprocess.
+    ///
+    /// The PATH probe is provenance-blind on purpose — the question is whether the tool is
+    /// usable, not whether brew is what put it there. A version manager's `node` satisfies
+    /// `brew: node`, and the system `git` satisfies `brew: acme/tools/git`.
+    func provides(_ package: String) -> Bool {
+        if shell.commandExists(Self.bareName(of: package)) { return true }
+        return isPackageInstalled(package)
+    }
+
     /// Install a Homebrew package.
     @discardableResult
     func install(_ name: String) -> ShellResult {
@@ -43,7 +65,7 @@ struct Homebrew {
     /// target leaves the Cellar path (e.g. npx → Cellar/node/.../npx → lib/node_modules/...).
     static func detectFormula(for command: String) -> String? {
         let fm = FileManager.default
-        let basename = URL(fileURLWithPath: command).lastPathComponent
+        let basename = bareName(of: command)
         for prefix in allPrefixes {
             let binPath = "\(prefix)/bin/\(basename)"
             guard let dest = try? fm.destinationOfSymbolicLink(atPath: binPath) else { continue }

--- a/Sources/mcs/Doctor/CoreDoctorChecks.swift
+++ b/Sources/mcs/Doctor/CoreDoctorChecks.swift
@@ -22,16 +22,18 @@ import Foundation
 //
 // This separation keeps `doctor --fix` predictable, and destructive only where it can show its work.
 
-struct CommandCheck: DoctorCheck {
+/// Reports on a `brew:` component, using the same availability test `installBrewPackage` uses
+/// so doctor and sync cannot disagree about what is installed.
+struct BrewPackageCheck: DoctorCheck {
     let name: String
     let section: String
-    let command: String
+    let package: String
     var isOptional: Bool = false
     var environment: Environment = .init()
 
     func check() -> CheckResult {
         let shell = ShellRunner(environment: environment)
-        if shell.commandExists(command) {
+        if Homebrew(shell: shell, environment: environment).provides(package) {
             return .pass("installed")
         }
         if isOptional {

--- a/Sources/mcs/Doctor/DerivedDoctorChecks.swift
+++ b/Sources/mcs/Doctor/DerivedDoctorChecks.swift
@@ -15,10 +15,10 @@ extension ComponentDefinition {
             return PluginCheck(pluginRef: PluginRef(pluginName), projectRoot: projectRoot, environment: environment)
 
         case let .brewInstall(package):
-            return CommandCheck(
+            return BrewPackageCheck(
                 name: displayName,
                 section: type.doctorSection,
-                command: package,
+                package: package,
                 isOptional: !isRequired,
                 environment: environment
             )

--- a/Sources/mcs/ExternalPack/PackHeuristics.swift
+++ b/Sources/mcs/ExternalPack/PackHeuristics.swift
@@ -315,13 +315,17 @@ enum PackHeuristics {
         return findings
     }
 
-    /// The `owner/tap` prefix of an `owner/tap/formula` name. Nil for a bare core formula, and
-    /// for a URL or path form — both of which also split into three parts, so they are rejected
-    /// before the count is consulted rather than reported as a tap called `https:/example.com`.
+    /// The `owner/tap` prefix of an `owner/tap/formula` name, when that tap is third-party.
+    ///
+    /// Nil for a bare core formula, for Homebrew's own taps (`homebrew/core`, `homebrew/cask`
+    /// and friends are first-party, and naming one explicitly is legal), and for URL and
+    /// path forms — those split into three parts too, so they are rejected up front rather
+    /// than reported as a tap called `https:/example.com` or `./Formula`.
     private static func tapReference(in package: String) -> String? {
-        guard !package.contains(":"), !package.hasPrefix("/") else { return nil }
+        guard !package.contains(":"), !package.hasPrefix("/"), !package.hasPrefix(".")
+        else { return nil }
         let parts = package.split(separator: "/")
-        guard parts.count == 3 else { return nil }
+        guard parts.count == 3, parts[0].lowercased() != "homebrew" else { return nil }
         return "\(parts[0])/\(parts[1])"
     }
 

--- a/Sources/mcs/ExternalPack/PackHeuristics.swift
+++ b/Sources/mcs/ExternalPack/PackHeuristics.swift
@@ -23,6 +23,7 @@ enum PackHeuristics {
             + checkRootLevelContentFiles(manifest: manifest, packPath: packPath)
         findings += unreferenced
         findings += checkMCPDependencyGaps(components: components)
+        findings += checkThirdPartyTaps(components: components)
         findings += checkPythonModulePaths(components: components, packPath: packPath)
         findings += checkDoctorCheckScopeUsage(manifest: manifest, components: components)
         findings += checkDoctorCheckMatcherUsage(manifest: manifest, components: components)
@@ -229,12 +230,14 @@ enum PackHeuristics {
         return findings
     }
 
-    /// Formulae the pack installs itself.
+    /// Formulae the pack installs itself, under every name they can be matched by — the bare
+    /// name too, or `brew: owner/tap/node` reads as "node is not installed by this pack".
     private static func brewPackages(in components: [ExternalComponentDefinition]) -> Set<String> {
         var packages = Set<String>()
         for component in components {
             if case let .brewInstall(package) = component.installAction {
                 packages.insert(package)
+                packages.insert(Homebrew.bareName(of: package))
             }
         }
         return packages
@@ -290,6 +293,36 @@ enum PackHeuristics {
         }
 
         return findings
+    }
+
+    /// A tap-qualified `brew:` package makes `brew install` clone and evaluate a third-party
+    /// repository. Homebrew auto-taps without asking, and mcs runs brew without a TTY so even
+    /// Homebrew's own plan prompt cannot fire — so the author is the last person able to weigh it.
+    private static func checkThirdPartyTaps(
+        components: [ExternalComponentDefinition]
+    ) -> [Finding] {
+        var findings: [Finding] = []
+        for component in components {
+            guard case let .brewInstall(package) = component.installAction,
+                  let tap = tapReference(in: package)
+            else { continue }
+            findings.append(Finding(
+                severity: .warning,
+                message: "Component '\(component.id)' installs '\(package)' from third-party tap"
+                    + " '\(tap)' — 'mcs sync' taps it without confirmation from Homebrew or mcs."
+            ))
+        }
+        return findings
+    }
+
+    /// The `owner/tap` prefix of an `owner/tap/formula` name. Nil for a bare core formula, and
+    /// for a URL or path form — both of which also split into three parts, so they are rejected
+    /// before the count is consulted rather than reported as a tap called `https:/example.com`.
+    private static func tapReference(in package: String) -> String? {
+        guard !package.contains(":"), !package.hasPrefix("/") else { return nil }
+        let parts = package.split(separator: "/")
+        guard parts.count == 3 else { return nil }
+        return "\(parts[0])/\(parts[1])"
     }
 
     /// A script language we refuse to guess an interpreter for, left to run under bash.

--- a/Sources/mcs/Sync/ComponentExecutor.swift
+++ b/Sources/mcs/Sync/ComponentExecutor.swift
@@ -12,13 +12,12 @@ struct ComponentExecutor {
 
     /// Install a Homebrew package, or confirm it's already available.
     func installBrewPackage(_ package: String) -> Bool {
-        if shell.commandExists(package) { return true }
         let brew = Homebrew(shell: shell, environment: environment)
+        if brew.provides(package) { return true }
         guard brew.isInstalled else {
             output.warn("Homebrew not found, cannot install \(package)")
             return false
         }
-        if brew.isPackageInstalled(package) { return true }
         let result = brew.install(package)
         if !result.succeeded {
             output.warn(String(result.stderr.prefix(200)))

--- a/Tests/MCSTests/DerivedDoctorCheckTests.swift
+++ b/Tests/MCSTests/DerivedDoctorCheckTests.swift
@@ -63,7 +63,7 @@ struct DerivedDoctorCheckTests {
         #expect(check?.section == "Plugins")
     }
 
-    @Test("brewInstall action derives CommandCheck")
+    @Test("brewInstall action derives BrewPackageCheck")
     func brewInstallDerivation() {
         let component = makeComponent(
             displayName: "TestPkg",
@@ -74,6 +74,18 @@ struct DerivedDoctorCheckTests {
         #expect(check != nil)
         #expect(check?.name == "TestPkg")
         #expect(check?.section == "Dependencies")
+        #expect((check as? BrewPackageCheck)?.package == "testpkg")
+    }
+
+    @Test("brewInstall derivation keeps a tap-qualified package intact")
+    func brewInstallDerivationTapQualified() {
+        let component = makeComponent(
+            displayName: "TestPkg",
+            type: .brewPackage,
+            installAction: .brewInstall(package: "getsentry/xcodebuildmcp/xcodebuildmcp")
+        )
+        let check = component.deriveDoctorCheck() as? BrewPackageCheck
+        #expect(check?.package == "getsentry/xcodebuildmcp/xcodebuildmcp")
     }
 
     @Test("shellCommand action returns nil (not derivable)")
@@ -275,7 +287,7 @@ struct DerivedDoctorCheckTests {
 
     @Test("allDoctorChecks returns derived + supplementary")
     func allDoctorChecksCombines() {
-        let supplementary = CommandCheck(name: "test", section: "Dependencies", command: "test")
+        let supplementary = BrewPackageCheck(name: "test", section: "Dependencies", package: "test")
         let component = makeComponent(
             displayName: "TestPkg",
             type: .brewPackage,
@@ -283,13 +295,13 @@ struct DerivedDoctorCheckTests {
             supplementaryChecks: [supplementary]
         )
         let checks = component.allDoctorChecks()
-        // 1 derived (CommandCheck from brewInstall) + 1 supplementary
+        // 1 derived (BrewPackageCheck from brewInstall) + 1 supplementary
         #expect(checks.count == 2)
     }
 
     @Test("shellCommand with supplementaryChecks returns only supplementary")
     func shellCommandWithSupplementary() {
-        let supplementary = CommandCheck(name: "brew", section: "Dependencies", command: "brew")
+        let supplementary = BrewPackageCheck(name: "brew", section: "Dependencies", package: "brew")
         let component = makeComponent(
             type: .brewPackage,
             installAction: .shellCommand(command: "curl ..."),

--- a/Tests/MCSTests/HomebrewTests.swift
+++ b/Tests/MCSTests/HomebrewTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+@testable import mcs
+import Testing
+
+@Suite("Homebrew")
+struct HomebrewTests {
+    // MARK: - bareName
+
+    @Test("bareName strips a tap qualifier and nothing else", arguments: [
+        (package: "getsentry/xcodebuildmcp/xcodebuildmcp", expected: "xcodebuildmcp"),
+        (package: "node", expected: "node"),
+        (package: "node@22", expected: "node@22"),
+    ])
+    func bareName(package: String, expected: String) {
+        #expect(Homebrew.bareName(of: package) == expected)
+    }
+
+    // MARK: - provides
+
+    @Test("provides takes the PATH fast path without spawning brew")
+    func providesUsesPath() {
+        let shell = MockShellRunner()
+        shell.commandExistsResult = true
+
+        #expect(Homebrew(shell: shell, environment: shell.environment).provides("node"))
+        #expect(shell.runCalls.isEmpty)
+    }
+
+    @Test("provides probes PATH under the bare name, not the tap-qualified one")
+    func providesProbesBareName() {
+        let shell = MockShellRunner()
+        shell.commandExistsResult = true
+
+        _ = Homebrew(shell: shell, environment: shell.environment)
+            .provides("getsentry/xcodebuildmcp/xcodebuildmcp")
+
+        #expect(shell.commandExistsCalls == ["xcodebuildmcp"])
+    }
+
+    /// The `ripgrep` → `rg` case: installed, but under a name PATH will never match.
+    @Test("provides falls back to brew when the command is not on PATH")
+    func providesFallsBackToBrew() {
+        let shell = MockShellRunner()
+        shell.commandExistsResult = false
+        shell.result = ShellResult(exitCode: 0, stdout: "", stderr: "")
+
+        #expect(Homebrew(shell: shell, environment: shell.environment).provides("ripgrep"))
+        #expect(shell.runCalls.last?.arguments == ["list", "ripgrep"])
+    }
+
+    @Test("provides asks brew about the tap-qualified name, which is the only one it knows")
+    func providesQueriesBrewWithFullName() {
+        let shell = MockShellRunner()
+        shell.commandExistsResult = false
+        shell.result = ShellResult(exitCode: 0, stdout: "", stderr: "")
+
+        _ = Homebrew(shell: shell, environment: shell.environment)
+            .provides("getsentry/xcodebuildmcp/xcodebuildmcp")
+
+        #expect(shell.runCalls.last?.arguments == ["list", "getsentry/xcodebuildmcp/xcodebuildmcp"])
+    }
+
+    @Test("provides is false when neither PATH nor brew has the package")
+    func providesFalseWhenAbsent() {
+        let shell = MockShellRunner()
+        shell.commandExistsResult = false
+        shell.result = ShellResult(exitCode: 1, stdout: "", stderr: "")
+
+        #expect(!Homebrew(shell: shell, environment: shell.environment).provides("nope"))
+    }
+}

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -166,6 +166,21 @@ private struct LifecycleTestBed {
         return file
     }
 
+    func brewComponent(
+        pack: String, id: String, package: String, isRequired: Bool = true
+    ) -> ComponentDefinition {
+        ComponentDefinition(
+            id: "\(pack).\(id)",
+            displayName: id,
+            description: "Brew \(id)",
+            type: .brewPackage,
+            packIdentifier: pack,
+            dependencies: [],
+            isRequired: isRequired,
+            installAction: .brewInstall(package: package)
+        )
+    }
+
     func settingsComponent(pack: String, id: String, source: URL) -> ComponentDefinition {
         ComponentDefinition(
             id: "\(pack).\(id)",
@@ -3072,5 +3087,57 @@ struct GitignoreRefCountTests {
 
         let after = try String(contentsOf: gitignore, encoding: .utf8)
         #expect(!after.contains(".solo-ignore"), "Nothing else claims it — ref counting must not over-keep")
+    }
+}
+
+@Suite("Brew package doctor checks")
+struct BrewPackageDoctorTests {
+    /// The ISSUE-388 regression: a tap-qualified package is on PATH only under its last
+    /// component, so a check testing the declared string reports a healthy install as missing.
+    ///
+    /// `git` stands in for a satisfied declaration rather than for a real tap install — the PATH
+    /// probe is provenance-blind by design, so the system `git` satisfies `acme/tools/git`. That
+    /// is what makes the test hermetic: it asserts the probe looks at the right *name*.
+    @Test("A tap-qualified brew package that is installed does not warn")
+    func tapQualifiedBrewPackagePassesDoctor() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let pack = MockTechPack(
+            identifier: "brew-pack",
+            displayName: "Brew Pack",
+            components: [bed.brewComponent(pack: "brew-pack", id: "tool", package: "acme/tools/git")]
+        )
+        let registry = TechPackRegistry(packs: [pack])
+
+        try bed.makeConfigurator(registry: registry).configure(packs: [pack], confirmRemovals: false)
+
+        var runner = bed.makeDoctorRunner(registry: registry)
+        let summary = try runner.run()
+        #expect(summary.warnings == 0)
+        #expect(summary.issues == 0)
+    }
+
+    /// Unlike its sibling this one does reach Homebrew: the PATH probe misses, so `provides`
+    /// falls through to a real `brew list`. That is read-only and returns the same answer with
+    /// or without Homebrew installed, but it is not free — roughly half a second.
+    @Test("An absent brew package is still reported")
+    func absentBrewPackageFailsDoctor() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let pack = MockTechPack(
+            identifier: "brew-pack",
+            displayName: "Brew Pack",
+            components: [bed.brewComponent(
+                pack: "brew-pack", id: "tool", package: "acme/tools/mcs-not-a-real-formula"
+            )]
+        )
+        let registry = TechPackRegistry(packs: [pack])
+
+        try bed.makeConfigurator(registry: registry).configure(packs: [pack], confirmRemovals: false)
+
+        var runner = bed.makeDoctorRunner(registry: registry)
+        #expect(try runner.run().issues > 0)
     }
 }

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -3097,7 +3097,9 @@ struct BrewPackageDoctorTests {
     ///
     /// `git` stands in for a satisfied declaration rather than for a real tap install — the PATH
     /// probe is provenance-blind by design, so the system `git` satisfies `acme/tools/git`. That
-    /// is what makes the test hermetic: it asserts the probe looks at the right *name*.
+    /// PATH hit is also what keeps the test hermetic: `configure` runs
+    /// `autoInstallGlobalDependencies` at *project* scope (global installs inline instead), so a
+    /// declaration it cannot satisfy would reach a real `brew install` and tap a real repository.
     @Test("A tap-qualified brew package that is installed does not warn")
     func tapQualifiedBrewPackagePassesDoctor() throws {
         let bed = try LifecycleTestBed()
@@ -3116,28 +3118,5 @@ struct BrewPackageDoctorTests {
         let summary = try runner.run()
         #expect(summary.warnings == 0)
         #expect(summary.issues == 0)
-    }
-
-    /// Unlike its sibling this one does reach Homebrew: the PATH probe misses, so `provides`
-    /// falls through to a real `brew list`. That is read-only and returns the same answer with
-    /// or without Homebrew installed, but it is not free — roughly half a second.
-    @Test("An absent brew package is still reported")
-    func absentBrewPackageFailsDoctor() throws {
-        let bed = try LifecycleTestBed()
-        defer { bed.cleanup() }
-
-        let pack = MockTechPack(
-            identifier: "brew-pack",
-            displayName: "Brew Pack",
-            components: [bed.brewComponent(
-                pack: "brew-pack", id: "tool", package: "acme/tools/mcs-not-a-real-formula"
-            )]
-        )
-        let registry = TechPackRegistry(packs: [pack])
-
-        try bed.makeConfigurator(registry: registry).configure(packs: [pack], confirmRemovals: false)
-
-        var runner = bed.makeDoctorRunner(registry: registry)
-        #expect(try runner.run().issues > 0)
     }
 }

--- a/Tests/MCSTests/PackHeuristicsTests.swift
+++ b/Tests/MCSTests/PackHeuristicsTests.swift
@@ -149,6 +149,21 @@ struct PackHeuristicsTests {
         })
     }
 
+    @Test("First-party and non-tap package forms are not reported as third-party taps", arguments: [
+        "homebrew/core/node",
+        "homebrew/cask/font-fira-code",
+        "./Formula/local.rb",
+        "https://example.com/formula.rb",
+    ])
+    func nonThirdPartyPackageFormsDoNotWarn(package: String) throws {
+        let tmpDir = try makeTmpDir(label: "heuristics")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let brew = brewComponent(package: package)
+        let findings = PackHeuristics.check(manifest: minimalManifest(components: [brew]), packPath: tmpDir)
+        #expect(!findings.contains { $0.message.contains("third-party tap") })
+    }
+
     @Test("A core formula is not reported as a third-party tap")
     func coreFormulaDoesNotWarnAboutTaps() throws {
         let tmpDir = try makeTmpDir(label: "heuristics")

--- a/Tests/MCSTests/PackHeuristicsTests.swift
+++ b/Tests/MCSTests/PackHeuristicsTests.swift
@@ -27,6 +27,20 @@ struct PackHeuristicsTests {
 
     // MARK: - Hook Interpreters
 
+    private func brewComponent(
+        id: String = "test-pack.brew",
+        displayName: String = "Brew",
+        package: String
+    ) -> ExternalComponentDefinition {
+        ExternalComponentDefinition(
+            id: id,
+            displayName: displayName,
+            description: "Brew \(displayName)",
+            type: .brewPackage,
+            installAction: .brewInstall(package: package)
+        )
+    }
+
     private func hookComponent(
         id: String = "test-pack.hook",
         source: String,
@@ -102,6 +116,47 @@ struct PackHeuristicsTests {
         ])
         let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
         #expect(!findings.contains { $0.message.contains("installs python") })
+    }
+
+    @Test("A tap-qualified formula satisfies the runtime requirement")
+    func tapQualifiedFormulaSatisfies() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let brew = brewComponent(id: "test-pack.node", displayName: "Node", package: "acme/tools/node")
+        let manifest = minimalManifest(components: [
+            brew,
+            hookComponent(source: "hooks/fmt.js", destination: "fmt.js"),
+        ])
+        let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
+        #expect(!findings.contains { $0.message.contains("installs node") })
+    }
+
+    @Test("A tap-qualified brew package is reported as a third-party tap")
+    func tapQualifiedPackageWarns() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let brew = brewComponent(
+            id: "test-pack.xcodebuildmcp",
+            displayName: "XcodeBuildMCP",
+            package: "getsentry/xcodebuildmcp/xcodebuildmcp"
+        )
+        let findings = PackHeuristics.check(manifest: minimalManifest(components: [brew]), packPath: tmpDir)
+        #expect(findings.contains {
+            $0.severity == .warning
+                && $0.message.contains("third-party tap 'getsentry/xcodebuildmcp'")
+        })
+    }
+
+    @Test("A core formula is not reported as a third-party tap")
+    func coreFormulaDoesNotWarnAboutTaps() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let brew = brewComponent(id: "test-pack.node", displayName: "Node", package: "node")
+        let findings = PackHeuristics.check(manifest: minimalManifest(components: [brew]), packPath: tmpDir)
+        #expect(!findings.contains { $0.message.contains("third-party tap") })
     }
 
     @Test("A versioned formula satisfies the runtime requirement")

--- a/Tests/MCSTests/TechPackRegistryTests.swift
+++ b/Tests/MCSTests/TechPackRegistryTests.swift
@@ -101,7 +101,7 @@ struct TechPackRegistryTests {
 
     @Test("supplementaryDoctorChecks returns checks for registered pack")
     func supplementaryDoctorChecksWithPack() {
-        let check = CommandCheck(name: "test-check", section: "Dependencies", command: "test")
+        let check = BrewPackageCheck(name: "test-check", section: "Dependencies", package: "test")
         let fakePack = FakeTechPack(
             identifier: "test-pack",
             supplementaryDoctorChecks: [check]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -361,6 +361,7 @@ The command (`Commands/ExportCommand.swift`) is a read-only `ParsableCommand` (n
 | **Non-Destructive** | User content in `CLAUDE.local.md` is preserved via `<!-- mcs:begin/end -->` section markers. Content outside markers is never touched. |
 | **Convergent** | Deselected packs are fully cleaned up — MCP servers removed, project files deleted, template sections stripped, settings keys cleaned. No orphaned artifacts. |
 | **Trust Verification** | Pack scripts are SHA-256 hashed at `mcs pack add` time and verified at load time. Modified scripts are detected and the user is prompted to re-trust before proceeding. Local packs skip verification since scripts change during development. |
+| **Trust Boundary** | `brew:` and `plugin:` install actions are outside trust review — they contribute no hashed item, so a pack declaring only those installs without a prompt, and changing one does not ask for renewed trust on `mcs pack update`. A tap-qualified `brew:` package is the case to watch: Homebrew taps a third-party repository and evaluates its formula without confirmation. |
 | **Lockfile (opt-in)** | `mcs.lock.yaml` pins pack commits for reproducible environments. Generation is off by default; enable with `mcs config set generate-lockfile true`. Explicit `generate-lockfile: false` is silent; only the never-configured `nil` state surfaces drift warnings against a stale pre-existing lockfile. Use `--lock` to check out pinned versions from an existing lockfile. `mcs update` honours `generate-lockfile`. |
 
 ## Concurrency Model

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,7 +140,7 @@ mcs pack validate ios            # Validate an installed pack by identifier
 | Severity | Exit code | Examples |
 |----------|-----------|---------|
 | Error | 1 | Empty pack (no components/templates/configure), `source: "."` copying entire pack root, missing settings file sources |
-| Warning | 0 | Unreferenced files in subdirectories, unreferenced root-level content files, MCP server using python/node without brew component, missing python module directory |
+| Warning | 0 | Unreferenced files in subdirectories, unreferenced root-level content files, MCP server using python/node without brew component, missing python module directory, `brew:` package installed from a third-party tap |
 
 Structural errors always cause exit code 1 and stop further analysis. Heuristic errors also cause exit code 1. Warnings are advisory and do not affect the exit code.
 

--- a/docs/creating-tech-packs.md
+++ b/docs/creating-tech-packs.md
@@ -120,7 +120,9 @@ components:
     brew: gh
 ```
 
-When a user runs `mcs sync`, these get installed via `brew install`. The engine auto-verifies them with `mcs doctor` (checks if the command is on PATH).
+When a user runs `mcs sync`, these get installed via `brew install`. The engine auto-verifies them with `mcs doctor`, which looks for the command on `PATH` and falls back to `brew list` — so a cask, a versioned formula like `node@22`, or a formula whose command is spelled differently (`ripgrep` installs `rg`) still verifies correctly.
+
+A tap-qualified package (`owner/tap/formula`) works too, but note that installing one taps a third-party repository without asking anyone; `mcs pack validate` warns when your pack declares one.
 
 Need to depend on Homebrew itself? That's a special case — Homebrew can't install itself, so use `shell:` with an explicit doctor check:
 
@@ -494,7 +496,7 @@ prompts:
 
 | Install action | Auto-derived check |
 |---|---|
-| `brew: node` | Is `node` on PATH? |
+| `brew: node` | Is `node` on PATH, or known to `brew list`? |
 | `mcp: {command: npx, ...}` | Is the MCP server registered? |
 | `plugin: "name@org"` | Is the plugin enabled? |
 | `hook: {source, destination}` | Does the hook file exist, and does its interpreter resolve? |

--- a/docs/techpack-schema.md
+++ b/docs/techpack-schema.md
@@ -62,6 +62,17 @@ Use one of these keys to define a component's install action. Each key infers th
 
 Infers: `type: brewPackage`, `installAction: brewInstall`
 
+Tap-qualified (`owner/tap/formula`) and versioned (`node@22`) names work, as do casks. The name is
+passed to `brew` verbatim; only the PATH probe behind the auto-derived check uses the last path
+component.
+
+> **Tapped formulae install from an unaudited source.** `brew install owner/tap/formula` clones the
+> tap's repository and evaluates its formula. Homebrew taps it without asking, and `mcs` runs `brew`
+> without a terminal, so Homebrew's own plan prompt cannot appear either. Nothing in `mcs` gates
+> this — `brew:` is outside the pack trust review. `mcs pack validate` warns about it at authoring
+> time, and users or organisations can restrict it with Homebrew's own `HOMEBREW_ALLOWED_TAPS` /
+> `HOMEBREW_FORBIDDEN_TAPS`, which are unset by default.
+
 ---
 
 #### `mcp:` — MCP Server
@@ -567,7 +578,7 @@ Most components get free doctor checks from their install action — no need to 
 
 | Shorthand | Auto-derived check |
 |-----------|-------------------|
-| `brew: node` | `commandExists` for `node` |
+| `brew: node` | Command on `PATH`, else `brew list` for the package. The `PATH` probe uses the last path component, so `owner/tap/formula` looks for `formula` |
 | `mcp: {command: npx, ...}` | MCP server registered in `~/.claude.json` |
 | `plugin: "name@org"` | Plugin enabled in settings |
 | `hook: {source, dest}` | File exists at destination, plus the interpreter binary resolves (skipped for `bash`/`sh`/`zsh`) |


### PR DESCRIPTION
## Summary

A component declaring `brew: owner/tap/formula` installs fine but `mcs doctor` reported it as `not found (optional)` on every run, and a pack author had no way to silence it. The check assumed a Homebrew package name is also the command name on `PATH` — true for core formulae, false for tapped ones, casks, versioned formulae like `node@22`, and any formula whose command is spelled differently (`ripgrep` provides `rg`). Sync already had the right test for this; doctor now uses the same one, so the two can no longer disagree about what is installed.

Closes #388

## Changes

- Availability is decided by `PATH` first and `brew list` second, so all four cases above verify correctly rather than warning forever.
- `mcs pack validate` warns when a component installs from a third-party tap. Installing one clones and evaluates an unaudited repository, and neither Homebrew nor mcs asks first — Homebrew auto-taps, and its own plan prompt needs a TTY that mcs never gives it.
- Documented that `brew:` and `plugin:` install actions sit outside the pack trust review, since nothing else in the tooling says so.

The one cost: a package that misses `PATH` now spends roughly half a second on `brew list`. Doctor runs checks sequentially, so a pack with several such packages pays that on every run. Left as-is deliberately — a cheaper filesystem probe exists, but swapping the mechanism is a design change rather than a bug fix.

The shorthand-key bug noted at the end of #388 is filed separately as #389; it is not fixed here.

## Test plan

- [x] `swift test` passes locally
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

Manual check, for a reviewer who wants one — note it writes to real `~/.mcs` state, as there is no sandboxed CLI mode:

- Declare `brew: <owner>/<tap>/<formula>` for a tapped formula you already have installed, then run `mcs doctor` → expect it reported as installed, not `not found (optional)`.
- Run `mcs pack validate` on that pack → expect a warning naming the third-party tap, and exit code 0.

<details>
<summary>Checklist for engine changes</summary>

- [x] Integration tests updated for new features (`LifecycleIntegrationTests` or `DoctorRunnerIntegrationTests`)
- [x] Docs updated if behavior changed (`CLAUDE.md`, `docs/`, `techpack.yaml` schema in `ExternalPackManifest.swift`)

</details>