### PR TITLE
Add a Closes line to the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,14 @@
 What does this PR do and why? One to three sentences.
 -->
 
+Closes #
+
+<!--
+GitHub auto-closes an issue only on a `Closes #N` reference in the body — the
+`ISSUE-N` prefix in the title does nothing on its own. Delete this line if the
+PR closes no issue.
+-->
+
 ## Changes
 
 <!--


### PR DESCRIPTION
## Summary

The `ISSUE-N` prefix this repo puts in PR titles has no effect on GitHub — only a `Closes #N` reference in the body auto-closes an issue. Every recent PR got that right by hand, but ISSUE-388 nearly shipped without it, which would have left the issue open after its fix merged. The template now carries the line so it is deleted deliberately rather than forgotten.

## Changes

- `Closes #` is now a template field under Summary, with a comment saying to delete it when the PR closes no issue.

## Test plan

- [ ] `swift test` passes locally
- [ ] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

No code changed — nothing to run. Open a PR after this merges and confirm the body is prefilled with the `Closes #` line.