### PR TITLE
Add 'mcs cleanup --all-projects' and short flags across the CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ mcs pack update [name]           # Refresh pack registry only (low-level fetch; 
 mcs pack validate [source]       # Validate a tech pack (path, identifier, or current directory)
 mcs cleanup                      # Find and delete backup files
 mcs cleanup --force              # Delete backups without confirmation
+mcs cleanup --all-projects       # Also scan every project tracked in ~/.mcs/projects.yaml
 mcs export <dir>                 # Export current config as a tech pack
 mcs export <dir> --global        # Export global scope (~/.claude/)
 mcs export <dir> --identifier id # Set pack identifier (prompted if omitted)

--- a/Sources/mcs/Commands/CheckUpdatesCommand.swift
+++ b/Sources/mcs/Commands/CheckUpdatesCommand.swift
@@ -10,7 +10,7 @@ struct CheckUpdatesCommand: ParsableCommand {
     @Flag(name: .long, help: "Run as a Claude Code SessionStart hook (respects 24-hour cooldown and config)")
     var hook: Bool = false
 
-    @Flag(name: .long, help: "Output results as JSON")
+    @Flag(name: .shortAndLong, help: "Output results as JSON")
     var json: Bool = false
 
     func run() throws {

--- a/Sources/mcs/Commands/CleanupCommand.swift
+++ b/Sources/mcs/Commands/CleanupCommand.swift
@@ -7,8 +7,14 @@ struct CleanupCommand: LockedCommand {
         abstract: "Find and delete backup files"
     )
 
-    @Flag(name: .long, help: "Delete backups without confirmation")
+    @Flag(name: .shortAndLong, help: "Delete backups without confirmation")
     var force: Bool = false
+
+    @Flag(
+        name: [.short, .customLong("all-projects")],
+        help: "Also scan every project tracked in the index (machine-wide)"
+    )
+    var allProjects: Bool = false
 
     func perform() throws {
         let env = Environment()
@@ -18,56 +24,59 @@ struct CleanupCommand: LockedCommand {
 
         output.header("Backup Cleanup")
 
-        // Scan directories for backups
-        var allBackups: [URL] = []
+        let scanner = BackupScanner(
+            environment: env,
+            currentDirectory: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        )
+        let groups = scanner.scan(includeTrackedProjects: allProjects, output: output)
+        let backups = groups.flatMap(\.backups)
 
-        // ~/.claude/
-        allBackups.append(contentsOf: Backup.findBackups(in: env.claudeDirectory))
-
-        // Current directory (if different from home)
-        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        if cwd.path != env.homeDirectory.path {
-            allBackups.append(contentsOf: Backup.findBackups(in: cwd))
-        }
-
-        // Deduplicate by path
-        var seen = Set<String>()
-        let unique = allBackups.filter { url in
-            let path = url.standardizedFileURL.path
-            if seen.contains(path) { return false }
-            seen.insert(path)
-            return true
-        }.sorted { $0.path < $1.path }
-
-        guard !unique.isEmpty else {
+        guard !backups.isEmpty else {
             output.success("No backup files found.")
             return
         }
 
-        output.info("Found \(unique.count) backup file(s):")
-        let fm = FileManager.default
-        for backup in unique {
-            let attrs = try? fm.attributesOfItem(atPath: backup.path)
-            let size = (attrs?[.size] as? Int) ?? 0
-            let sizeStr = ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
-            output.plain("  \(backup.lastPathComponent) (\(sizeStr))")
+        output.info("Found \(backups.count) backup file(s):")
+        for group in groups {
+            output.plain("")
+            output.plain("  \(label(for: group))")
+            for backup in group.backups {
+                let name = PathContainment.relativePath(of: backup.path, within: group.root.path)
+                output.plain("    \(name) (\(formattedSize(of: backup)))")
+            }
         }
 
         output.plain("")
 
-        if force || output.askYesNo("Delete all \(unique.count) backup file(s)?", default: false) {
-            let failures = Backup.deleteBackups(unique)
-            let deleted = unique.count - failures.count
-            if failures.isEmpty {
-                output.success("Deleted \(deleted) backup file(s).")
-            } else {
-                output.warn("Deleted \(deleted) backup(s), \(failures.count) could not be deleted:")
-                for failure in failures {
-                    output.warn("  \(failure.url.lastPathComponent): \(failure.error.localizedDescription)")
-                }
-            }
-        } else {
+        guard force || output.askYesNo("Delete all \(backups.count) backup file(s)?", default: false) else {
             output.info("No backups deleted.")
+            return
         }
+
+        let failures = Backup.deleteBackups(backups)
+        let deleted = backups.count - failures.count
+        if failures.isEmpty {
+            output.success("Deleted \(deleted) backup file(s).")
+        } else {
+            output.warn("Deleted \(deleted) backup(s), \(failures.count) could not be deleted:")
+            for failure in failures {
+                output.warn("  \(failure.url.path): \(failure.error.localizedDescription)")
+            }
+        }
+    }
+
+    private func label(for group: BackupScanner.Group) -> String {
+        let kind = switch group.kind {
+        case .global: "Global"
+        case .currentDirectory: "Current directory"
+        case .project: "Project"
+        }
+        return "\(kind) (\(group.root.path))"
+    }
+
+    private func formattedSize(of file: URL) -> String {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: file.path)
+        let size = (attrs?[.size] as? Int) ?? 0
+        return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
     }
 }

--- a/Sources/mcs/Commands/CleanupCommand.swift
+++ b/Sources/mcs/Commands/CleanupCommand.swift
@@ -42,7 +42,7 @@ struct CleanupCommand: LockedCommand {
             output.plain("  \(label(for: group))")
             for backup in group.backups {
                 let name = PathContainment.relativePath(of: backup.path, within: group.root.path)
-                output.plain("    \(name) (\(formattedSize(of: backup)))")
+                output.plain("    \(name) (\(formattedSize(of: backup, output: output)))")
             }
         }
 
@@ -74,9 +74,16 @@ struct CleanupCommand: LockedCommand {
         return "\(kind) (\(group.root.path))"
     }
 
-    private func formattedSize(of file: URL) -> String {
-        let attrs = try? FileManager.default.attributesOfItem(atPath: file.path)
-        let size = (attrs?[.size] as? Int) ?? 0
-        return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+    /// A file listed by the scan but unreadable now is one the delete pass will also fail on,
+    /// so the reason is worth saying out loud rather than rendering as a plausible zero.
+    private func formattedSize(of file: URL, output: CLIOutput) -> String {
+        do {
+            let attrs = try FileManager.default.attributesOfItem(atPath: file.path)
+            guard let size = attrs[.size] as? Int else { return "size unknown" }
+            return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+        } catch {
+            output.warn("Could not read \(file.path): \(error.localizedDescription)")
+            return "size unknown"
+        }
     }
 }

--- a/Sources/mcs/Commands/DoctorCommand.swift
+++ b/Sources/mcs/Commands/DoctorCommand.swift
@@ -7,16 +7,16 @@ struct DoctorCommand: LockedCommand {
         abstract: "Check installation health and diagnose issues"
     )
 
-    @Flag(name: .long, help: "Attempt to automatically fix issues")
+    @Flag(name: .shortAndLong, help: "Attempt to automatically fix issues")
     var fix = false
 
     @Flag(name: .shortAndLong, help: "Skip confirmation prompt before applying fixes")
     var yes = false
 
-    @Option(name: .long, help: "Only check a specific tech pack (e.g. ios)")
+    @Option(name: .shortAndLong, help: "Only check a specific tech pack (e.g. ios)")
     var pack: String?
 
-    @Flag(name: .long, help: "Check globally-configured packs only")
+    @Flag(name: .shortAndLong, help: "Check globally-configured packs only")
     var global = false
 
     var skipLock: Bool {

--- a/Sources/mcs/Commands/ExportCommand.swift
+++ b/Sources/mcs/Commands/ExportCommand.swift
@@ -14,13 +14,13 @@ struct ExportCommand: ParsableCommand {
     @Argument(help: "Output directory for the generated pack")
     var outputDir: String
 
-    @Flag(name: .long, help: "Export global scope (~/.claude/) instead of project scope")
+    @Flag(name: .shortAndLong, help: "Export global scope (~/.claude/) instead of project scope")
     var global = false
 
-    @Option(name: .long, help: "Pack identifier (prompted if omitted)")
+    @Option(name: .shortAndLong, help: "Pack identifier (prompted if omitted)")
     var identifier: String?
 
-    @Flag(name: .long, help: "Include everything without prompts")
+    @Flag(name: [.customShort("y"), .long], help: "Include everything without prompts")
     var nonInteractive = false
 
     @Flag(name: .long, help: "Preview what would be exported without writing")

--- a/Sources/mcs/Commands/PackCommand.swift
+++ b/Sources/mcs/Commands/PackCommand.swift
@@ -44,10 +44,10 @@ struct AddPack: LockedCommand {
     @Argument(help: "Git URL, GitHub shorthand (user/repo), or local path")
     var source: String
 
-    @Option(name: .long, help: "Git tag, branch, or commit (git packs only)")
+    @Option(name: .shortAndLong, help: "Git tag, branch, or commit (git packs only)")
     var ref: String?
 
-    @Flag(name: .long, help: "Preview pack contents without installing")
+    @Flag(name: .shortAndLong, help: "Preview pack contents without installing")
     var preview: Bool = false
 
     var skipLock: Bool {
@@ -432,7 +432,7 @@ struct RemovePack: LockedCommand {
     @Argument(help: "Pack identifier to remove")
     var identifier: String
 
-    @Flag(name: .long, help: "Skip confirmation prompt")
+    @Flag(name: .shortAndLong, help: "Skip confirmation prompt")
     var force: Bool = false
 
     func perform() throws {

--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -10,22 +10,22 @@ struct SyncCommand: LockedCommand {
     @Argument(help: "Path to the project directory (defaults to current directory)")
     var path: String?
 
-    @Option(name: .long, help: "Tech pack to apply (e.g. ios). Can be specified multiple times.")
+    @Option(name: .shortAndLong, help: "Tech pack to apply (e.g. ios). Can be specified multiple times.")
     var pack: [String] = []
 
-    @Flag(name: .long, help: "Apply all registered packs without prompts")
+    @Flag(name: .shortAndLong, help: "Apply all registered packs without prompts")
     var all: Bool = false
 
     @Flag(name: .long, help: "Show what would change without making any modifications")
     var dryRun = false
 
-    @Flag(name: .long, help: "Checkout locked pack versions from mcs.lock.yaml before syncing")
+    @Flag(name: .shortAndLong, help: "Checkout locked pack versions from mcs.lock.yaml before syncing")
     var lock = false
 
-    @Flag(name: .long, help: "Customize which components to include per pack")
+    @Flag(name: .shortAndLong, help: "Customize which components to include per pack")
     var customize = false
 
-    @Flag(name: .long, help: "Install to global scope (MCP servers with user scope, files to ~/.claude/)")
+    @Flag(name: .shortAndLong, help: "Install to global scope (MCP servers with user scope, files to ~/.claude/)")
     var global = false
 
     var skipLock: Bool {

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -14,13 +14,16 @@ struct UpdateCommand: LockedCommand {
     @Argument(help: "Path to the project directory (defaults to current directory)")
     var path: String?
 
-    @Flag(name: .long, help: "Only refresh the global scope")
+    @Flag(name: .shortAndLong, help: "Only refresh the global scope")
     var global: Bool = false
 
-    @Flag(name: .long, help: "Only refresh the current project's scope")
+    @Flag(name: .shortAndLong, help: "Only refresh the current project's scope")
     var project: Bool = false
 
-    @Flag(name: .customLong("all-projects"), help: "Refresh every project in the index plus the global scope (fan out machine-wide)")
+    @Flag(
+        name: [.short, .customLong("all-projects")],
+        help: "Refresh every project in the index plus the global scope (fan out machine-wide)"
+    )
     var allProjects: Bool = false
 
     @Flag(name: .long, help: "Show what would change without making any modifications")

--- a/Sources/mcs/Core/Backup.swift
+++ b/Sources/mcs/Core/Backup.swift
@@ -28,12 +28,13 @@ struct Backup {
     }
 
     /// Find all backup files matching `*.backup.*` under the given directory.
-    static func findBackups(in directory: URL) -> [URL] {
+    /// Pass `recursive: false` to look only at the directory's own entries.
+    static func findBackups(in directory: URL, recursive: Bool = true) -> [URL] {
         let fm = FileManager.default
         guard let enumerator = fm.enumerator(
             at: directory,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: []
+            includingPropertiesForKeys: nil,
+            options: recursive ? [] : [.skipsSubdirectoryDescendants]
         ) else {
             return []
         }
@@ -41,6 +42,10 @@ struct Backup {
         var backups: [URL] = []
         for case let url as URL in enumerator
             where url.lastPathComponent.contains(".backup.") {
+            // A directory can carry the pattern too, and deleting one takes its contents with it.
+            var isDirectory: ObjCBool = false
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue else { continue }
             backups.append(url)
         }
         return backups

--- a/Sources/mcs/Core/BackupScanner.swift
+++ b/Sources/mcs/Core/BackupScanner.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Discovers backup files across the scopes `mcs cleanup` can reach, grouped by the
+/// scope that owns them.
+struct BackupScanner {
+    let environment: Environment
+    let currentDirectory: URL
+
+    /// Backups found under one scope, with the root their paths are displayed against.
+    struct Group {
+        enum Kind {
+            case global
+            case currentDirectory
+            case project
+        }
+
+        let kind: Kind
+        let root: URL
+        let backups: [URL]
+    }
+
+    func scan(includeTrackedProjects: Bool, output: CLIOutput) -> [Group] {
+        var targets: [(kind: Group.Kind, root: URL)] = [(.global, environment.claudeDirectory)]
+
+        if currentDirectory.standardizedFileURL.path != environment.homeDirectory.standardizedFileURL.path {
+            targets.append((.currentDirectory, currentDirectory))
+        }
+
+        if includeTrackedProjects {
+            // A project the user is already standing in is covered by the scope above;
+            // scanning it again would walk the same tree for results `seen` then discards.
+            let covered = Set(targets.map(\.root.standardizedFileURL.path))
+            targets += trackedProjects(output: output)
+                .filter { !covered.contains($0.path) }
+                .map { (.project, $0) }
+        }
+
+        var seen: Set<String> = []
+        return targets.compactMap { target in
+            var found: [URL] = []
+            for url in backups(in: target.root, kind: target.kind) {
+                guard seen.insert(url.standardizedFileURL.path).inserted else { continue }
+                found.append(url)
+            }
+            guard !found.isEmpty else { return nil }
+            return Group(kind: target.kind, root: target.root, backups: found.sorted { $0.path < $1.path })
+        }
+    }
+
+    /// A tracked project is swept at its root and under `.claude/` only — the two places sync
+    /// writes a backup. Every project on the machine walked in full would put unrelated
+    /// `*.backup.*` user files on the deletion list; a scope the user named themselves is
+    /// narrow enough to sweep whole.
+    private func backups(in root: URL, kind: Group.Kind) -> [URL] {
+        switch kind {
+        case .global, .currentDirectory:
+            Backup.findBackups(in: root)
+        case .project:
+            Backup.findBackups(in: root, recursive: false)
+                + Backup.findBackups(in: root.appendingPathComponent(Constants.FileNames.claudeDirectory))
+        }
+    }
+
+    /// Projects recorded in `~/.mcs/projects.yaml` that still exist on disk.
+    private func trackedProjects(output: CLIOutput) -> [URL] {
+        let index = ProjectIndex(path: environment.projectsIndexFile)
+        do {
+            return try index.existingProjectURLs(in: index.load())
+        } catch {
+            output.warn("Could not read the project index — scanning local scopes only: \(error.localizedDescription)")
+            return []
+        }
+    }
+}

--- a/Sources/mcs/Core/ProjectIndex.swift
+++ b/Sources/mcs/Core/ProjectIndex.swift
@@ -28,6 +28,12 @@ struct ProjectIndex {
         var url: URL? {
             isGlobal ? nil : URL(fileURLWithPath: path)
         }
+
+        /// Whether the entry's directory is still on disk. The global sentinel is always present.
+        var directoryExists: Bool {
+            guard let url else { return true }
+            return FileManager.default.fileExists(atPath: url.path)
+        }
     }
 
     struct IndexData: Codable {
@@ -96,20 +102,25 @@ struct ProjectIndex {
         data.projects.filter { $0.packs.contains(packID) }
     }
 
+    /// Project directories still on disk, sorted by path. Excludes the `__global__` sentinel.
+    func existingProjectURLs(in data: IndexData) -> [URL] {
+        data.projects
+            .filter(\.directoryExists)
+            .compactMap(\.url)
+            .map(\.standardizedFileURL)
+            .sorted { $0.path < $1.path }
+    }
+
     /// Remove entries for project directories that no longer exist on disk.
     /// The `__global__` sentinel is never pruned.
     /// Returns the pruned paths for reporting.
     @discardableResult
     func pruneStale(in data: inout IndexData) -> [String] {
-        let fm = FileManager.default
         var pruned: [String] = []
         data.projects.removeAll { entry in
-            guard entry.path != Self.globalSentinel else { return false }
-            if !fm.fileExists(atPath: entry.path) {
-                pruned.append(entry.path)
-                return true
-            }
-            return false
+            guard !entry.directoryExists else { return false }
+            pruned.append(entry.path)
+            return true
         }
         return pruned
     }

--- a/Sources/mcs/Sync/ResourceRefCounter.swift
+++ b/Sources/mcs/Sync/ResourceRefCounter.swift
@@ -147,7 +147,6 @@ struct ResourceRefCounter {
     ) -> Bool {
         guard var indexData = cachedIndexData() else { return true }
 
-        let fm = FileManager.default
         var stalePaths: [String] = []
         var stillNeeded = false
 
@@ -157,12 +156,9 @@ struct ResourceRefCounter {
             // by *declaration* would keep resources the pack never actually installed.
             if entry.path == scopePath, entry.path == ProjectIndex.globalSentinel { continue }
 
-            // Validate project still exists (skip __global__ — always valid)
-            if entry.path != ProjectIndex.globalSentinel {
-                guard fm.fileExists(atPath: entry.path) else {
-                    stalePaths.append(entry.path)
-                    continue
-                }
+            guard entry.directoryExists else {
+                stalePaths.append(entry.path)
+                continue
             }
 
             // Check each pack in this scope. The scope being removed is still scanned — a

--- a/Tests/MCSTests/BackupScannerTests.swift
+++ b/Tests/MCSTests/BackupScannerTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+@testable import mcs
+import Testing
+
+struct BackupScannerTests {
+    private func makeSandbox() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mcs-scanner-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.standardizedFileURL
+    }
+
+    private func writeFile(_ url: URL, _ contents: String = "x") throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func makeProject(in sandbox: URL, named name: String) throws -> URL {
+        let root = sandbox.appendingPathComponent(name)
+        try writeFile(root.appendingPathComponent("CLAUDE.local.md.backup.20260101_101010_1"))
+        try writeFile(root.appendingPathComponent(".claude/settings.local.json.backup.20260101_101010_2"))
+        return root
+    }
+
+    private func indexProjects(_ paths: [URL], home: URL) throws {
+        let index = ProjectIndex(path: Environment(home: home).projectsIndexFile)
+        var data = ProjectIndex.IndexData()
+        for path in paths {
+            index.upsert(projectPath: path.path, packIDs: ["ios"], in: &data)
+        }
+        index.upsert(projectPath: ProjectIndex.globalSentinel, packIDs: ["ios"], in: &data)
+        try index.save(data)
+    }
+
+    private func names(_ groups: [BackupScanner.Group]) -> Set<String> {
+        Set(groups.flatMap(\.backups).map(\.lastPathComponent))
+    }
+
+    @Test("scan finds global and current-directory backups without the fan-out flag")
+    func scanLocalScopes() throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let home = sandbox.appendingPathComponent("home")
+        try writeFile(home.appendingPathComponent(".claude/CLAUDE.md.backup.20260101_101010_1"))
+        let cwd = try makeProject(in: sandbox, named: "cwd-project")
+        let tracked = try makeProject(in: sandbox, named: "tracked")
+        try indexProjects([tracked], home: home)
+
+        let scanner = BackupScanner(environment: Environment(home: home), currentDirectory: cwd)
+        let groups = scanner.scan(includeTrackedProjects: false, output: CLIOutput(colorsEnabled: false))
+
+        #expect(groups.count == 2)
+        #expect(names(groups) == [
+            "CLAUDE.md.backup.20260101_101010_1",
+            "CLAUDE.local.md.backup.20260101_101010_1",
+            "settings.local.json.backup.20260101_101010_2",
+        ])
+    }
+
+    @Test("scan with tracked projects adds every indexed project")
+    func scanTrackedProjects() throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let home = sandbox.appendingPathComponent("home")
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent(".claude"), withIntermediateDirectories: true
+        )
+        let cwd = sandbox.appendingPathComponent("elsewhere")
+        try FileManager.default.createDirectory(at: cwd, withIntermediateDirectories: true)
+        let alpha = try makeProject(in: sandbox, named: "alpha")
+        let beta = try makeProject(in: sandbox, named: "beta")
+        try indexProjects([alpha, beta], home: home)
+
+        let scanner = BackupScanner(environment: Environment(home: home), currentDirectory: cwd)
+        let groups = scanner.scan(includeTrackedProjects: true, output: CLIOutput(colorsEnabled: false))
+
+        #expect(groups.count == 2)
+        #expect(groups.map(\.root.path) == [alpha.path, beta.path])
+        #expect(groups.flatMap(\.backups).count == 4)
+    }
+
+    @Test("tracked-project scan skips deep files but keeps the project root and .claude")
+    func scanTrackedProjectsIsShallowAtRoot() throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let home = sandbox.appendingPathComponent("home")
+        let project = try makeProject(in: sandbox, named: "alpha")
+        try writeFile(project.appendingPathComponent("node_modules/dep/db.backup.2024"))
+        try writeFile(project.appendingPathComponent(".claude/skills/deep/s.md.backup.20260101_101010_3"))
+        try indexProjects([project], home: home)
+
+        let scanner = BackupScanner(
+            environment: Environment(home: home), currentDirectory: home
+        )
+        let groups = scanner.scan(includeTrackedProjects: true, output: CLIOutput(colorsEnabled: false))
+
+        #expect(names(groups) == [
+            "CLAUDE.local.md.backup.20260101_101010_1",
+            "settings.local.json.backup.20260101_101010_2",
+            "s.md.backup.20260101_101010_3",
+        ])
+    }
+
+    @Test("a project reachable from two scopes is reported once")
+    func scanDeduplicatesAcrossScopes() throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let home = sandbox.appendingPathComponent("home")
+        let project = try makeProject(in: sandbox, named: "alpha")
+        try indexProjects([project], home: home)
+
+        let scanner = BackupScanner(environment: Environment(home: home), currentDirectory: project)
+        let groups = scanner.scan(includeTrackedProjects: true, output: CLIOutput(colorsEnabled: false))
+
+        #expect(groups.count == 1)
+        #expect(groups[0].root.path == project.path)
+        #expect(groups[0].backups.count == 2)
+    }
+
+    @Test("index entries for deleted projects are ignored")
+    func scanSkipsStaleIndexEntries() throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let home = sandbox.appendingPathComponent("home")
+        let gone = sandbox.appendingPathComponent("deleted-project")
+        try indexProjects([gone], home: home)
+
+        let scanner = BackupScanner(environment: Environment(home: home), currentDirectory: home)
+        let groups = scanner.scan(includeTrackedProjects: true, output: CLIOutput(colorsEnabled: false))
+
+        #expect(groups.isEmpty)
+    }
+
+    @Test("a directory matching the backup pattern is not offered for deletion")
+    func scanIgnoresDirectories() throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let home = sandbox.appendingPathComponent("home")
+        let cwd = sandbox.appendingPathComponent("project")
+        try writeFile(cwd.appendingPathComponent("skills.backup.20260101_101010_1/keep.md"))
+
+        let scanner = BackupScanner(environment: Environment(home: home), currentDirectory: cwd)
+        let groups = scanner.scan(includeTrackedProjects: false, output: CLIOutput(colorsEnabled: false))
+
+        #expect(groups.isEmpty)
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,12 +19,12 @@ mcs sync --lock                  # Checkout locked versions from mcs.lock.yaml
 | Flag | Description |
 |------|-------------|
 | `[path]` | Project directory (defaults to current directory) |
-| `--pack <name>` | Apply a specific pack non-interactively. Repeatable for multiple packs. |
-| `--all` | Apply all registered packs without interactive selection. |
+| `-p, --pack <name>` | Apply a specific pack non-interactively. Repeatable for multiple packs. |
+| `-a, --all` | Apply all registered packs without interactive selection. |
 | `--dry-run` | Preview changes without writing any files. |
-| `--customize` | Per-pack component selection (deselect individual components). |
-| `--global` | Sync global-scope components (brew packages, plugins, MCP servers to `~/.claude/`). |
-| `--lock` | Check out the commits pinned in `mcs.lock.yaml`. |
+| `-c, --customize` | Per-pack component selection (deselect individual components). |
+| `-g, --global` | Sync global-scope components (brew packages, plugins, MCP servers to `~/.claude/`). |
+| `-l, --lock` | Check out the commits pinned in `mcs.lock.yaml`. |
 
 `mcs sync` is also the default command — running `mcs` alone is equivalent to `mcs sync`.
 
@@ -43,9 +43,9 @@ mcs update --dry-run             # Preview without making changes
 | Flag | Description |
 |------|-------------|
 | `[path]` | Project directory (defaults to current directory) |
-| `--global` | Only refresh the global scope. Mutually exclusive with `--project` and `--all-projects`. |
-| `--project` | Only refresh the current project's scope. Mutually exclusive with `--global` and `--all-projects`. |
-| `--all-projects` | Refresh the global scope plus every project tracked in `~/.mcs/projects.yaml`. Asks for confirmation in interactive mode and lists the affected projects first. Mutually exclusive with `--global` and `--project`. |
+| `-g, --global` | Only refresh the global scope. Mutually exclusive with `--project` and `--all-projects`. |
+| `-p, --project` | Only refresh the current project's scope. Mutually exclusive with `--global` and `--all-projects`. |
+| `-a, --all-projects` | Refresh the global scope plus every project tracked in `~/.mcs/projects.yaml`. Asks for confirmation in interactive mode and lists the affected projects first. Mutually exclusive with `--global` and `--project`. |
 | `--dry-run` | Preview changes without writing any files. |
 
 `mcs update` always refreshes the full configured set of every selected scope. To advance a single pack's registry pointer without applying anywhere, use [`mcs pack update <name>`](#mcs-pack-update-name).
@@ -82,8 +82,8 @@ mcs pack add <url> --preview     # Preview pack contents without installing
 
 | Flag | Description |
 |------|-------------|
-| `--ref <tag>` | Pin to a specific git tag, branch, or commit (git packs only). |
-| `--preview` | Preview the pack's contents without installing. |
+| `-r, --ref <tag>` | Pin to a specific git tag, branch, or commit (git packs only). |
+| `-p, --preview` | Preview the pack's contents without installing. |
 
 Source resolution order: URL schemes → filesystem paths → GitHub shorthand.
 
@@ -159,10 +159,10 @@ mcs doctor --global              # Check globally-configured packs only
 
 | Flag | Description |
 |------|-------------|
-| `--fix` | Auto-fix issues where possible (re-add gitignore entries, create missing state files, etc.). |
+| `-f, --fix` | Auto-fix issues where possible (re-add gitignore entries, create missing state files, etc.). |
 | `-y, --yes` | Skip confirmation prompt before applying fixes (use with `--fix`). |
-| `--pack <name>` | Only check a specific pack. |
-| `--global` | Only check globally-configured packs. |
+| `-p, --pack <name>` | Only check a specific pack. |
+| `-g, --global` | Only check globally-configured packs. |
 
 Doctor resolves packs from: explicit `--pack` flag → project `.mcs-project` state → `CLAUDE.local.md` section markers → global manifest.
 
@@ -173,7 +173,18 @@ Find and delete timestamped backup files created during sync.
 ```bash
 mcs cleanup                      # List backups and confirm before deleting
 mcs cleanup --force              # Delete backups without confirmation
+mcs cleanup --all-projects       # Also scan every project tracked in the index
 ```
+
+| Flag | Description |
+|------|-------------|
+| `-f, --force` | Delete without confirmation. |
+| `-a, --all-projects` | Also scan every project tracked in `~/.mcs/projects.yaml`. |
+
+Without `--all-projects`, cleanup scans `~/.claude/` and the current directory. With it,
+each tracked project is scanned at its root (top level only) plus `<project>/.claude/` in
+full — the two places sync writes backups. Index entries whose directory no longer exists
+are skipped.
 
 ## `mcs export`
 
@@ -190,9 +201,9 @@ mcs export <dir> --dry-run       # Preview what would be exported
 | Flag | Description |
 |------|-------------|
 | `<dir>` | Output directory for the generated pack. |
-| `--global` | Export global scope (`~/.claude/`) instead of the current project. |
-| `--identifier id` | Set the pack identifier (prompted interactively if omitted). |
-| `--non-interactive` | Include all discovered artifacts without prompting for selection. |
+| `-g, --global` | Export global scope (`~/.claude/`) instead of the current project. |
+| `-i, --identifier id` | Set the pack identifier (prompted interactively if omitted). |
+| `-y, --non-interactive` | Include all discovered artifacts without prompting for selection. |
 | `--dry-run` | Preview what would be exported without writing files. |
 
 The export wizard discovers MCP servers, hooks, skills, commands, agents, plugins, `CLAUDE.md` sections, gitignore entries (global only), and settings. Sensitive env vars are replaced with `__PLACEHOLDER__` tokens and corresponding `prompts:` entries are generated.
@@ -210,7 +221,7 @@ mcs check-updates --json         # Machine-readable JSON output
 | Flag | Description |
 |------|-------------|
 | `--hook` | Run as a Claude Code SessionStart hook. Respects the 24-hour cooldown and config keys. Without this flag, always fetches from remote. |
-| `--json` | Output results as JSON instead of human-readable text. |
+| `-j, --json` | Output results as JSON instead of human-readable text. |
 
 **How it works:**
 - **Pack checks**: Runs `git ls-remote` per pack to compare the remote HEAD against the local commit SHA. Local packs are skipped.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,6 +96,10 @@ mcs pack remove <name>           # Remove with confirmation
 mcs pack remove <name> --force   # Remove without confirmation
 ```
 
+| Flag | Description |
+|------|-------------|
+| `-f, --force` | Skip the confirmation prompt. |
+
 Removal is federated: `mcs` discovers all projects using the pack (via the project index) and runs convergence cleanup for each scope.
 
 ### `mcs pack list`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -289,6 +289,7 @@ Over time, `mcs sync` creates timestamped backups of files it modifies.
 ```bash
 mcs cleanup          # Lists backups and asks before deleting
 mcs cleanup --force  # Deletes without confirmation
+mcs cleanup --all-projects  # Also scans every project tracked in the index
 ```
 
 ## Getting More Help


### PR DESCRIPTION
## Summary

Backups pile up in every synced project, but cleanup could only see `~/.claude` and the current directory — collecting them meant `cd`-ing into each project in turn. This mirrors `mcs update --all-projects`. Separately, every flag was long-only.

## Changes

- `mcs cleanup --all-projects` also scans every project in the index, grouping results by scope so identically-named backups stay distinguishable
- A tracked project is swept at its root and under `.claude/` rather than in full: those are the only places sync writes a backup, and a deep sweep would put unrelated `*.backup.*` files machine-wide on the deletion list
- A directory matching the backup pattern is no longer offered for deletion — it was, and deleting it took its contents along
- Most flags gained a short form. `-p` is `--pack` in sync and doctor but `--project` in update, which has no `--pack` by design; `--dry-run` stays long-only

## Test plan

- [x] `swift test` passes locally
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [x] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

<details>
<summary>Checklist for engine changes</summary>

- [x] Docs updated if behavior changed (`CLAUDE.md`, `docs/`)

</details>
