### PR TITLE
Stop the project picker and MCP trust prompt firing on every sync

### DIFF
--- a/Sources/mcs/ExternalPack/PackTrustManager.swift
+++ b/Sources/mcs/ExternalPack/PackTrustManager.swift
@@ -37,7 +37,10 @@ struct PackTrustManager {
                         type: .mcpServerCommand,
                         relativePath: nil,
                         content: serverDesc,
-                        description: "MCP server — runs on every Claude Code session"
+                        // Scoped per component for the same reason `.hookInterpreter` below is: a
+                        // pack declaring two MCP servers put both under one key, and whichever
+                        // lost the write re-prompted on every update.
+                        description: "\(component.id) — MCP server, runs on every Claude Code session"
                     ))
 
                 case let .copyPackFile(config):

--- a/Sources/mcs/ExternalPack/PromptExecutor.swift
+++ b/Sources/mcs/ExternalPack/PromptExecutor.swift
@@ -28,8 +28,8 @@ struct PromptExecutor {
     ///   - packPath: Root directory of the external pack
     ///   - projectPath: Current project root directory
     ///   - priorValue: Value resolved in a previous sync, used as the default for
-    ///     `input`/`select` prompts. Ignored for `script` and `fileDetect` (both
-    ///     re-compute every sync).
+    ///     `input`/`select` prompts and as the pre-selected file for `fileDetect`.
+    ///     Ignored for `script`, which re-computes every sync.
     /// - Returns: The resolved value string
     func execute(
         prompt: PromptDefinition,
@@ -39,7 +39,7 @@ struct PromptExecutor {
     ) throws -> String {
         switch prompt.type {
         case .fileDetect:
-            try executeFileDetect(prompt: prompt, projectPath: projectPath)
+            try executeFileDetect(prompt: prompt, projectPath: projectPath, priorValue: priorValue)
         case .input:
             executeInput(prompt: prompt, priorValue: priorValue)
         case .select:
@@ -80,9 +80,12 @@ struct PromptExecutor {
     // MARK: - File Detect
 
     /// Scan for files matching one or more patterns and present a selector.
+    /// `priorValue` pre-selects the file chosen last sync — pattern order decides the
+    /// cursor otherwise, which can land on a sibling of the file the user actually picked.
     private func executeFileDetect(
         prompt: PromptDefinition,
-        projectPath: URL
+        projectPath: URL,
+        priorValue: String?
     ) throws -> String {
         let patterns = prompt.detectPatterns ?? ["*"]
         let files = Self.detectFiles(matching: patterns, in: projectPath)
@@ -108,7 +111,8 @@ struct PromptExecutor {
                 return (name: name, description: ext.isEmpty ? "File" : ext)
             }
             let label = prompt.label ?? "Select a file"
-            let selected = output.singleSelect(title: label, items: items)
+            let initialIndex = priorValue.flatMap { files.firstIndex(of: $0) } ?? 0
+            let selected = output.singleSelect(title: label, items: items, initialIndex: initialIndex)
             return files[selected]
         }
     }

--- a/Sources/mcs/Sync/Configurator.swift
+++ b/Sources/mcs/Sync/Configurator.swift
@@ -716,7 +716,8 @@ struct Configurator {
     /// Reuses values from the previous sync when safe:
     /// - `input` priors are reused verbatim.
     /// - `select` priors are reused only if the stored value is still a valid option.
-    /// - `script` and `fileDetect` always re-execute (computed / filesystem-dependent).
+    /// - `fileDetect` priors are reused only if this run's scan still finds the stored file.
+    /// - `script` always re-executes (computed, never answered).
     private func resolveAllValues(
         packs: [any TechPack],
         state: inout ProjectState,
@@ -733,12 +734,13 @@ struct Configurator {
             packs: packs, context: initialContext
         )
         let (reusableValues, newDeclaredKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            allDeclaredPrompts, priorValues: priorValues
+            allDeclaredPrompts, priorValues: priorValues, projectPath: initialContext.projectPath
         )
 
         let seedFromPriors = decideSeedStrategy(
             reusableValues: reusableValues,
             newDeclaredKeys: newDeclaredKeys,
+            visibleValueKeys: CrossPackPromptResolver.visibleValueKeys(in: allDeclaredPrompts),
             customize: customize,
             reusePriorValuesSilently: reusePriorValuesSilently
         )
@@ -795,12 +797,14 @@ struct Configurator {
     /// acknowledgement (visible in CI logs, not loud). Interactive with new prompts
     /// added since last sync reuses old values and prompts only for the new ones.
     /// Interactive with only reusable prompts shows the key list (values masked —
-    /// prompts often hold secrets) and gates on a single Y/n.
+    /// prompts often hold secrets, except the `visibleValueKeys` the packs scanned
+    /// off disk) and gates on a single Y/n.
     /// `reusePriorValuesSilently` (set by `mcs update`) collapses the interactive-only
     /// branches into the same silent-reuse path used for non-interactive runs.
     private func decideSeedStrategy(
         reusableValues: [String: String],
         newDeclaredKeys: Set<String>,
+        visibleValueKeys: Set<String>,
         customize: Bool,
         reusePriorValuesSilently: Bool
     ) -> Bool {
@@ -828,9 +832,11 @@ struct Configurator {
         }
 
         output.plain("")
-        output.info("Previously configured keys (values hidden — prompts may hold secrets):")
-        for key in reusableValues.keys.sorted() {
-            output.dimmed("  \(key)")
+        output.info("Previously configured keys (values hidden where they may hold secrets):")
+        for line in ConfiguratorSupport.reusableKeysListing(
+            reusableValues: reusableValues, visibleValueKeys: visibleValueKeys
+        ) {
+            output.dimmed(line)
         }
         return output.askYesNo("Reuse these values?", default: true)
     }

--- a/Sources/mcs/Sync/ConfiguratorSupport.swift
+++ b/Sources/mcs/Sync/ConfiguratorSupport.swift
@@ -69,6 +69,23 @@ enum ConfiguratorSupport {
             ]
     }
 
+    /// The reuse gate's per-key listing, one line per key, sorted.
+    ///
+    /// Values stay hidden unless the key is in `visibleValueKeys`: prompts commonly hold MCP
+    /// credentials, and the gate is printed to a terminal the user may be sharing. Pure so the
+    /// redaction itself is testable — `CLIOutput` writes straight to stdout with no capture seam.
+    static func reusableKeysListing(
+        reusableValues: [String: String],
+        visibleValueKeys: Set<String>
+    ) -> [String] {
+        reusableValues.keys.sorted().map { key in
+            guard visibleValueKeys.contains(key), let value = reusableValues[key] else {
+                return "  \(key)"
+            }
+            return "  \(key): \(value)"
+        }
+    }
+
     /// Emit `projectDuplicationWarning`, doing nothing outside the global scope.
     ///
     /// The scope gate lives here rather than at each call site: only a global install can create

--- a/Sources/mcs/Sync/CrossPackPromptResolver.swift
+++ b/Sources/mcs/Sync/CrossPackPromptResolver.swift
@@ -3,8 +3,9 @@ import Foundation
 /// Collects prompt definitions from multiple packs, identifies shared keys,
 /// and executes shared prompts once with a combined display showing each pack's label.
 ///
-/// Only `input` and `select` prompt types are eligible for deduplication.
-/// `script` and `fileDetect` types are pack-specific and always run per-pack.
+/// Only `input` and `select` prompt types are eligible for deduplication; `script` and
+/// `fileDetect` are pack-specific and always resolve per-pack. Per-pack is not per-sync:
+/// a `fileDetect` prior that `partitionDeclaredPrompts` accepts skips the executor entirely.
 enum CrossPackPromptResolver {
     /// A prompt definition paired with the pack that declares it.
     struct PackPromptInfo {

--- a/Sources/mcs/Sync/CrossPackPromptResolver.swift
+++ b/Sources/mcs/Sync/CrossPackPromptResolver.swift
@@ -15,6 +15,14 @@ enum CrossPackPromptResolver {
     /// Prompt types eligible for cross-pack deduplication.
     static let deduplicableTypes: Set<PromptType> = [.input, .select]
 
+    /// Prompt types whose prior value can survive into the next sync. `script` is absent
+    /// because its value is computed, not answered — re-running it costs the user nothing.
+    static let reusableTypes: Set<PromptType> = [.input, .select, .fileDetect]
+
+    /// Prompt types whose resolved value is safe to print back to the user. Only types the pack
+    /// resolves by scanning: everything a user typed is treated as potentially secret.
+    static let visibleValueTypes: Set<PromptType> = [.fileDetect]
+
     /// Flat list of every declaration from every pack. Multiple packs can declare
     /// the same key — `partitionDeclaredPrompts` groups them when merging select options.
     static func collectDeclaredPrompts(
@@ -26,8 +34,8 @@ enum CrossPackPromptResolver {
 
     /// Partition declared prompts against `priorValues`.
     ///
-    /// `script` and `fileDetect` keys are excluded from both outputs — they always
-    /// re-run and must not trigger the "new prompts" UX branch.
+    /// `script` keys are excluded from both outputs — they always re-execute and must
+    /// not trigger the "new prompts" UX branch.
     ///
     /// Select priors are reusable when:
     /// - no declaration constrains the value (all have nil/empty options — the executor
@@ -39,24 +47,37 @@ enum CrossPackPromptResolver {
     /// the prior must satisfy those constraints (matches `resolveSharedPrompts` which
     /// presents the merged constrained option list to the user).
     ///
+    /// `fileDetect` priors are reusable only when this run's scan still finds the stored
+    /// file: the scan stays dynamic, but a project that hasn't changed stops re-asking.
+    /// An empty scan re-asks, mirroring the executor's zero-match branch, which prompts.
+    ///
     /// Type conflicts across packs (input vs select) fall back to input semantics.
+    ///
+    /// - Parameter projectPath: Directory the `fileDetect` patterns are scanned in.
     static func partitionDeclaredPrompts(
         _ prompts: [PromptDefinition],
-        priorValues: [String: String]
+        priorValues: [String: String],
+        projectPath: URL
     ) -> (reusableValues: [String: String], newDeclaredKeys: Set<String>) {
         var constrainedOptionsByKey: [String: Set<String>] = [:]
-        var typesByKey: [String: Set<PromptType>] = [:]
+        var detectedFilesByKey: [String: Set<String>] = [:]
         for prompt in prompts {
-            typesByKey[prompt.key, default: []].insert(prompt.type)
             if prompt.type == .select, let options = prompt.options, !options.isEmpty {
                 constrainedOptionsByKey[prompt.key, default: []].formUnion(options.map(\.value))
+            }
+            // Only a prior can be validated against the scan, so a key without one skips it.
+            if prompt.type == .fileDetect, priorValues[prompt.key] != nil {
+                let detected = PromptExecutor.detectFiles(
+                    matching: prompt.detectPatterns ?? ["*"], in: projectPath
+                )
+                detectedFilesByKey[prompt.key, default: []].formUnion(detected)
             }
         }
 
         var reusable: [String: String] = [:]
         var newKeys: Set<String> = []
-        for (key, types) in typesByKey {
-            let answerableTypes = types.intersection(deduplicableTypes)
+        for (key, types) in typesByKey(in: prompts) {
+            let answerableTypes = types.intersection(reusableTypes)
             guard !answerableTypes.isEmpty else { continue }
 
             guard let prior = priorValues[key] else {
@@ -64,19 +85,39 @@ enum CrossPackPromptResolver {
                 continue
             }
 
-            if answerableTypes == [.select] {
-                let constrained = constrainedOptionsByKey[key] ?? []
-                // No constraints → free-form; any constraint → prior must satisfy it.
-                if constrained.isEmpty || constrained.contains(prior) {
-                    reusable[key] = prior
-                } else {
-                    newKeys.insert(key)
-                }
+            let constrained = constrainedOptionsByKey[key] ?? []
+            let permitted: Bool = if answerableTypes.contains(.input) {
+                true
+            } else if answerableTypes.contains(.fileDetect) {
+                detectedFilesByKey[key, default: []].contains(prior)
             } else {
+                // No constraints → free-form; any constraint → prior must satisfy it.
+                constrained.isEmpty || constrained.contains(prior)
+            }
+
+            if permitted {
                 reusable[key] = prior
+            } else {
+                newKeys.insert(key)
             }
         }
         return (reusable, newKeys)
+    }
+
+    /// Keys whose value every declaring pack resolves by scanning, per `visibleValueTypes`.
+    /// A key any pack declares as another type stays hidden — the same conservative rule the
+    /// reuse partition applies to mixed declarations.
+    static func visibleValueKeys(in prompts: [PromptDefinition]) -> Set<String> {
+        Set(typesByKey(in: prompts).filter { $0.value.isSubset(of: visibleValueTypes) }.keys)
+    }
+
+    /// Every type each key is declared as, across all packs.
+    private static func typesByKey(in prompts: [PromptDefinition]) -> [String: Set<PromptType>] {
+        var typesByKey: [String: Set<PromptType>] = [:]
+        for prompt in prompts {
+            typesByKey[prompt.key, default: []].insert(prompt.type)
+        }
+        return typesByKey
     }
 
     /// Collect prompts from all packs and group by key, skipping already-resolved keys.

--- a/Tests/MCSTests/CrossPackPromptResolverTests.swift
+++ b/Tests/MCSTests/CrossPackPromptResolverTests.swift
@@ -609,6 +609,25 @@ struct ScannerExtensionTests {
 // MARK: - partitionDeclaredPrompts
 
 struct PartitionDeclaredPromptsTests {
+    /// Scan directory for prompt sets that declare no `fileDetect`, so nothing is ever scanned.
+    private let unscannedPath = FileManager.default.temporaryDirectory
+
+    static let projectPrompt = PromptDefinition(
+        key: "PROJECT", type: .fileDetect,
+        label: nil, defaultValue: nil, options: nil,
+        detectPatterns: ["*.xcodeproj", "*.xcworkspace"], scriptCommand: nil
+    )
+
+    private func makeDetectDir(files: [String]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mcs-partition-detect-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        for file in files {
+            try "".write(to: dir.appendingPathComponent(file), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
     @Test("partition: input prompt with prior becomes reusable")
     func partitionInputPriorReusable() {
         let prompt = PromptDefinition(
@@ -617,7 +636,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [prompt], priorValues: ["BRANCH_PREFIX": "bruno"]
+            [prompt], priorValues: ["BRANCH_PREFIX": "bruno"],
+            projectPath: unscannedPath
         )
         #expect(reusable == ["BRANCH_PREFIX": "bruno"])
         #expect(newKeys.isEmpty)
@@ -631,7 +651,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [prompt], priorValues: [:]
+            [prompt], priorValues: [:],
+            projectPath: unscannedPath
         )
         #expect(reusable.isEmpty)
         #expect(newKeys == ["NEW_KEY"])
@@ -649,7 +670,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [prompt], priorValues: ["LOG_LEVEL": "debug"]
+            [prompt], priorValues: ["LOG_LEVEL": "debug"],
+            projectPath: unscannedPath
         )
         #expect(reusable == ["LOG_LEVEL": "debug"])
         #expect(newKeys.isEmpty)
@@ -667,7 +689,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [prompt], priorValues: ["LOG_LEVEL": "trace-removed"]
+            [prompt], priorValues: ["LOG_LEVEL": "trace-removed"],
+            projectPath: unscannedPath
         )
         #expect(reusable.isEmpty)
         #expect(newKeys == ["LOG_LEVEL"])
@@ -688,7 +711,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [fromPackA, fromPackB], priorValues: ["REGION": "eu"]
+            [fromPackA, fromPackB], priorValues: ["REGION": "eu"],
+            projectPath: unscannedPath
         )
         #expect(reusable == ["REGION": "eu"])
         #expect(newKeys.isEmpty)
@@ -703,7 +727,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [prompt], priorValues: ["FREEFORM": "anything"]
+            [prompt], priorValues: ["FREEFORM": "anything"],
+            projectPath: unscannedPath
         )
         #expect(reusable == ["FREEFORM": "anything"])
         #expect(newKeys.isEmpty)
@@ -718,7 +743,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, _) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [prompt], priorValues: ["FREEFORM": "anything"]
+            [prompt], priorValues: ["FREEFORM": "anything"],
+            projectPath: unscannedPath
         )
         #expect(reusable == ["FREEFORM": "anything"])
     }
@@ -740,7 +766,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [constrained, unconstrained], priorValues: ["REGION": "zz"]
+            [constrained, unconstrained], priorValues: ["REGION": "zz"],
+            projectPath: unscannedPath
         )
         #expect(reusable.isEmpty)
         #expect(newKeys == ["REGION"])
@@ -761,7 +788,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, _) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [constrained, unconstrained], priorValues: ["REGION": "us"]
+            [constrained, unconstrained], priorValues: ["REGION": "us"],
+            projectPath: unscannedPath
         )
         #expect(reusable == ["REGION": "us"])
     }
@@ -799,7 +827,8 @@ struct PartitionDeclaredPromptsTests {
 
         // Downstream partition sees both declarations → "eu" from pack B validates.
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            collected, priorValues: ["REGION": "eu"]
+            collected, priorValues: ["REGION": "eu"],
+            projectPath: unscannedPath
         )
         #expect(reusable == ["REGION": "eu"])
         #expect(newKeys.isEmpty)
@@ -813,24 +842,84 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: "echo 1.0"
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [prompt], priorValues: ["VERSION": "0.9"]
+            [prompt], priorValues: ["VERSION": "0.9"],
+            projectPath: unscannedPath
         )
         #expect(reusable.isEmpty)
         #expect(newKeys.isEmpty)
     }
 
-    @Test("partition: fileDetect prompt is neither reusable nor newDeclared")
-    func partitionFileDetectExcluded() {
-        let prompt = PromptDefinition(
-            key: "PROJECT", type: .fileDetect,
+    @Test("partition: fileDetect prior still on disk is reusable")
+    func partitionFileDetectPriorStillDetected() throws {
+        let dir = try makeDetectDir(files: ["App.xcodeproj", "App.xcworkspace"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
+            [Self.projectPrompt], priorValues: ["PROJECT": "App.xcworkspace"], projectPath: dir
+        )
+        #expect(reusable == ["PROJECT": "App.xcworkspace"])
+        #expect(newKeys.isEmpty)
+    }
+
+    @Test("partition: fileDetect prior no longer detected becomes newDeclared")
+    func partitionFileDetectPriorGone() throws {
+        let dir = try makeDetectDir(files: ["Renamed.xcodeproj"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
+            [Self.projectPrompt], priorValues: ["PROJECT": "App.xcworkspace"], projectPath: dir
+        )
+        #expect(reusable.isEmpty)
+        #expect(newKeys == ["PROJECT"])
+    }
+
+    @Test("partition: fileDetect prior in an empty directory becomes newDeclared")
+    func partitionFileDetectEmptyDirectory() throws {
+        let dir = try makeDetectDir(files: [])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
+            [Self.projectPrompt], priorValues: ["PROJECT": "App.xcworkspace"], projectPath: dir
+        )
+        #expect(reusable.isEmpty)
+        #expect(newKeys == ["PROJECT"])
+    }
+
+    @Test("partition: fileDetect declared as input by another pack keeps verbatim reuse")
+    func partitionFileDetectMixedWithInput() throws {
+        let dir = try makeDetectDir(files: ["Other.xcodeproj"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let asInput = PromptDefinition(
+            key: "PROJECT", type: .input,
+            label: nil, defaultValue: nil, options: nil,
+            detectPatterns: nil, scriptCommand: nil
+        )
+        let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
+            [Self.projectPrompt, asInput],
+            priorValues: ["PROJECT": "App.xcworkspace"],
+            projectPath: dir
+        )
+        #expect(reusable == ["PROJECT": "App.xcworkspace"])
+        #expect(newKeys.isEmpty)
+    }
+
+    @Test("visibleValueKeys covers scan-resolved keys and excludes mixed declarations")
+    func visibleValueKeysPartitionByDeclaration() {
+        let mixed = PromptDefinition(
+            key: "SHARED", type: .input,
+            label: nil, defaultValue: nil, options: nil,
+            detectPatterns: nil, scriptCommand: nil
+        )
+        let mixedDetect = PromptDefinition(
+            key: "SHARED", type: .fileDetect,
             label: nil, defaultValue: nil, options: nil,
             detectPatterns: ["*.xcodeproj"], scriptCommand: nil
         )
-        let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [prompt], priorValues: ["PROJECT": "App.xcodeproj"]
+        let keys = CrossPackPromptResolver.visibleValueKeys(
+            in: [Self.projectPrompt, mixed, mixedDetect]
         )
-        #expect(reusable.isEmpty)
-        #expect(newKeys.isEmpty)
+        #expect(keys == ["PROJECT"])
     }
 
     @Test("partition: type conflict falls back to input reuse semantics")
@@ -847,7 +936,8 @@ struct PartitionDeclaredPromptsTests {
             detectPatterns: nil, scriptCommand: nil
         )
         let (reusable, newKeys) = CrossPackPromptResolver.partitionDeclaredPrompts(
-            [asInput, asSelect], priorValues: ["SHARED": "anything"]
+            [asInput, asSelect], priorValues: ["SHARED": "anything"],
+            projectPath: unscannedPath
         )
         #expect(reusable == ["SHARED": "anything"])
         #expect(newKeys.isEmpty)

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -1859,6 +1859,18 @@ struct PromptValueReuseLifecycleTests {
         )
     }
 
+    private func fileDetectPrompt(_ key: String, patterns: [String]) -> PromptDefinition {
+        PromptDefinition(
+            key: key, type: .fileDetect,
+            label: nil, defaultValue: nil, options: nil,
+            detectPatterns: patterns, scriptCommand: nil
+        )
+    }
+
+    private func touch(_ name: String, in directory: URL) throws {
+        try "".write(to: directory.appendingPathComponent(name), atomically: true, encoding: .utf8)
+    }
+
     private func selectPrompt(_ key: String, options: [String]) -> PromptDefinition {
         PromptDefinition(
             key: key, type: .select,
@@ -1972,6 +1984,57 @@ struct PromptValueReuseLifecycleTests {
         let state2 = try bed.projectState()
         // "trace" is no longer valid → partition treats as newDeclared → mock returns default "info"
         #expect(state2.resolvedValues?["LOG_LEVEL"] == "info")
+    }
+
+    @Test("fileDetect prior still on disk is reused instead of re-detected")
+    func fileDetectReuseOnSecondSync() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        try touch("App.xcodeproj", in: bed.project)
+        try touch("App.xcworkspace", in: bed.project)
+
+        let pack = MockPromptTechPack(
+            identifier: "detect-pack",
+            displayName: "Detect Pack",
+            prompts: [fileDetectPrompt("PROJECT", patterns: ["*.xcodeproj", "*.xcworkspace"])],
+            defaultAnswer: { _ in "re-asked" }
+        )
+        let configurator = bed.makeConfigurator(registry: TechPackRegistry(packs: [pack]))
+
+        try configurator.configure(packs: [pack], confirmRemovals: false)
+        #expect(try bed.projectState().resolvedValues?["PROJECT"] == "re-asked")
+
+        var state = try bed.projectState()
+        state.setResolvedValues(["PROJECT": "App.xcworkspace"])
+        try state.save()
+
+        try configurator.configure(packs: [pack], confirmRemovals: false)
+        #expect(try bed.projectState().resolvedValues?["PROJECT"] == "App.xcworkspace")
+    }
+
+    @Test("fileDetect prior is re-asked once the stored file is gone")
+    func fileDetectStalePriorReAsks() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        try touch("App.xcodeproj", in: bed.project)
+
+        let pack = MockPromptTechPack(
+            identifier: "detect-pack",
+            displayName: "Detect Pack",
+            prompts: [fileDetectPrompt("PROJECT", patterns: ["*.xcodeproj", "*.xcworkspace"])],
+            defaultAnswer: { _ in "re-asked" }
+        )
+        let configurator = bed.makeConfigurator(registry: TechPackRegistry(packs: [pack]))
+        try configurator.configure(packs: [pack], confirmRemovals: false)
+
+        var state = try bed.projectState()
+        state.setResolvedValues(["PROJECT": "Removed.xcworkspace"])
+        try state.save()
+
+        try configurator.configure(packs: [pack], confirmRemovals: false)
+        #expect(try bed.projectState().resolvedValues?["PROJECT"] == "re-asked")
     }
 
     @Test("Non-interactive sync reuses priors silently")

--- a/Tests/MCSTests/PackTrustManagerTests.swift
+++ b/Tests/MCSTests/PackTrustManagerTests.swift
@@ -307,6 +307,46 @@ struct PackTrustManagerTests {
         #expect(items[0].content.contains("TestServer"))
     }
 
+    @Test("Two MCP servers in one pack get separate trust keys and stay trusted")
+    func twoMCPServersDoNotShareATrustKey() throws {
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let yaml = """
+        schemaVersion: 1
+        identifier: test
+        displayName: Test Pack
+        description: A test pack
+        version: "1.0.0"
+        components:
+          - id: test.first
+            displayName: First
+            description: A command-based MCP server
+            mcp:
+              name: FirstServer
+              command: first-server
+              args:
+                - mcp
+          - id: test.second
+            displayName: Second
+            description: An HTTP MCP server
+            mcp:
+              url: https://example.test/mcp
+        """
+        let manifest = try loadManifest(yaml: yaml, in: tmpDir)
+        let manager = PackTrustManager(output: CLIOutput(colorsEnabled: false))
+        let items = try manager.analyzeScripts(manifest: manifest, packPath: tmpDir)
+        #expect(items.count == 2)
+
+        let hashes = try manager.computeScriptHashes(items: items, packPath: tmpDir)
+        #expect(hashes.count == 2)
+
+        // Both servers verify against the map their own approval produced — the collision made
+        // one of them re-prompt on every update, no matter how often it was approved.
+        let unapproved = manager.newOrChanged(in: items, against: hashes, packPath: tmpDir)
+        #expect(unapproved.isEmpty)
+    }
+
     @Test("analyzeScripts surfaces commandExists doctor check commands")
     func analyzeScriptsCommandExists() throws {
         let tmpDir = try makeTmpDir()

--- a/Tests/MCSTests/PromptExecutorTests.swift
+++ b/Tests/MCSTests/PromptExecutorTests.swift
@@ -449,4 +449,62 @@ struct PromptExecutorTests {
 
         #expect(value == "3.0.0")
     }
+
+    @Test("fileDetect prompt pre-selects the prior when several files match")
+    func fileDetectPromptPreSelectsPrior() throws {
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        try "".write(to: tmpDir.appendingPathComponent("App.xcodeproj"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("App.xcworkspace"), atomically: true, encoding: .utf8)
+
+        let prompt = PromptDefinition(
+            key: "PROJECT",
+            type: .fileDetect,
+            label: "Xcode project / workspace",
+            defaultValue: nil,
+            options: nil,
+            detectPatterns: ["*.xcodeproj", "*.xcworkspace"],
+            scriptCommand: nil
+        )
+
+        let executor = makeExecutor()
+        let value = try executor.execute(
+            prompt: prompt,
+            packPath: tmpDir,
+            projectPath: tmpDir,
+            priorValue: "App.xcworkspace"
+        )
+
+        #expect(value == "App.xcworkspace")
+    }
+
+    @Test("fileDetect prompt falls back to the first match when the prior is gone")
+    func fileDetectPromptIgnoresMissingPrior() throws {
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        try "".write(to: tmpDir.appendingPathComponent("App.xcodeproj"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Other.xcodeproj"), atomically: true, encoding: .utf8)
+
+        let prompt = PromptDefinition(
+            key: "PROJECT",
+            type: .fileDetect,
+            label: "Xcode project",
+            defaultValue: nil,
+            options: nil,
+            detectPatterns: ["*.xcodeproj"],
+            scriptCommand: nil
+        )
+
+        let executor = makeExecutor()
+        let value = try executor.execute(
+            prompt: prompt,
+            packPath: tmpDir,
+            projectPath: tmpDir,
+            priorValue: "Renamed.xcodeproj"
+        )
+
+        #expect(value == "App.xcodeproj")
+    }
 }

--- a/Tests/MCSTests/SyncCommandTests.swift
+++ b/Tests/MCSTests/SyncCommandTests.swift
@@ -307,6 +307,26 @@ struct SyncCommandTests {
         #expect(lines[1] == "    Backend → /dev/b")
         #expect(lines[2] == "    iOS → /dev/a")
     }
+
+    // MARK: - Reuse gate listing
+
+    @Test("Reuse listing shows scan-derived values and redacts everything else")
+    func reuseListingRedactsUserEnteredValues() {
+        let lines = ConfiguratorSupport.reusableKeysListing(
+            reusableValues: ["API_TOKEN": "sk-secret", "PROJECT": "App.xcworkspace"],
+            visibleValueKeys: ["PROJECT"]
+        )
+        #expect(lines == ["  API_TOKEN", "  PROJECT: App.xcworkspace"])
+    }
+
+    @Test("Reuse listing redacts every value when nothing is scan-derived")
+    func reuseListingRedactsAllByDefault() {
+        let lines = ConfiguratorSupport.reusableKeysListing(
+            reusableValues: ["B_KEY": "two", "A_KEY": "one"],
+            visibleValueKeys: []
+        )
+        #expect(lines == ["  A_KEY", "  B_KEY"])
+    }
 }
 
 // MARK: - Guard: cwd inside ~/.claude detection

--- a/Tests/MCSTests/TestHelpers.swift
+++ b/Tests/MCSTests/TestHelpers.swift
@@ -244,6 +244,10 @@ struct MockPromptTechPack: TechPack {
             if prompt.type == .select, let prior, let options = prompt.options,
                !options.contains(where: { $0.value == prior }) {
                 resolved[prompt.key] = defaultAnswer(prompt.key)
+            } else if prompt.type == .fileDetect {
+                // The real executor re-scans and asks when a fileDetect key reaches it,
+                // so reaching this branch at all means the prior was not reused.
+                resolved[prompt.key] = defaultAnswer(prompt.key)
             } else {
                 resolved[prompt.key] = prior ?? defaultAnswer(prompt.key)
             }

--- a/docs/creating-tech-packs.md
+++ b/docs/creating-tech-packs.md
@@ -453,7 +453,7 @@ See the [Schema Reference](techpack-schema.md#the-ignore-field) for full semanti
 
 Prompts gather values from the user during `mcs sync`. These values are available as `__KEY__` placeholders in templates, settings files, MCP server configs, and copyPackFile artifacts — and as `MCS_RESOLVED_KEY` environment variables in scripts.
 
-When multiple packs declare prompts with the same `key` (e.g., both a core pack and an iOS pack want `BRANCH_PREFIX`), the user is asked **once** with a combined display. Only `input` and `select` types are deduplicated — `fileDetect` and `script` always run per-pack.
+When multiple packs declare prompts with the same `key` (e.g., both a core pack and an iOS pack want `BRANCH_PREFIX`), the user is asked **once** with a combined display. Only `input` and `select` types are deduplicated — `fileDetect` and `script` always resolve per-pack. A `fileDetect` answer is still reused on later syncs while the scan finds the same file; `script` re-runs every time.
 
 ```yaml
 prompts:

--- a/docs/techpack-schema.md
+++ b/docs/techpack-schema.md
@@ -442,7 +442,7 @@ prompts:
 
 | Type | Behavior |
 |------|----------|
-| `fileDetect` | Scans the project directory for files matching the glob pattern(s). If one match is found, it's used automatically. If multiple, the user picks one. |
+| `fileDetect` | Scans the project directory for files matching the glob pattern(s). If one match is found, it's used automatically. If multiple, the user picks one — and on a later sync that choice is reused while the scan still finds it. |
 | `input` | Free-text input with optional default value. |
 | `select` | Choose from a predefined list of options. |
 | `script` | Runs a shell command and uses its stdout as the value. |
@@ -451,7 +451,7 @@ prompts:
 
 When multiple packs declare prompts with the same `key`, `mcs` detects the overlap and asks the user **once** with a combined display showing each pack's label. The resolved value is shared across all packs.
 
-Only `input` and `select` prompts are eligible for deduplication. `fileDetect` and `script` prompts are too pack-specific and always run per-pack.
+Only `input` and `select` prompts are eligible for deduplication. `fileDetect` and `script` prompts are too pack-specific and always resolve per-pack. Deduplication is separate from reuse: a `fileDetect` answer stored by an earlier sync is reused while the current scan still finds that file, so the picker does not reappear on every run. `script` prompts re-execute every sync.
 
 For shared `select` prompts, options are merged across packs (deduplicated by value, first occurrence wins). If one pack uses `input` and another uses `select` for the same key, the prompt falls back to `input` with a warning.
 


### PR DESCRIPTION
## Summary

Syncing an iOS project meant answering the same two questions every time: which Xcode
project to use, and whether to trust the pack's MCP servers. Both were engine bugs
rather than pack ones — a stored project answer was never consulted on the next run,
and two MCP servers declared by one pack shared a single trust slot, so approving
either one invalidated the other. Confirmed on a real project: one final re-trust
prompt, then silence.

## Changes

- A detected-file answer survives into the next sync while the scan still finds it; a renamed or deleted file asks again
- When the picker does appear it opens on the stored answer instead of the first pattern's match
- Each MCP server gets its own trust key; the remaining item types keyed off unvalidated names are tracked in #393
- The reuse gate shows values a pack found by scanning and keeps user-typed ones masked

## Test plan

- [x] `swift test` passes locally
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [x] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)
- Sync a project holding both `*.xcodeproj` and `*.xcworkspace` twice → the second run asks nothing
- Delete the stored file, sync again → the picker returns, opening on nothing stale

<details>
<summary>Checklist for engine changes</summary>

- [x] Integration tests updated for new features (`LifecycleIntegrationTests` or `DoctorRunnerIntegrationTests`)

</details>